### PR TITLE
ConfineMetaClassChanges for classes that are used in actual and mock form

### DIFF
--- a/src/test/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorIntegrationTest.groovy
+++ b/src/test/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorIntegrationTest.groovy
@@ -18,6 +18,7 @@ import com.sonatype.nexus.api.iq.ApplicationPolicyEvaluation
 import com.sonatype.nexus.api.iq.internal.InternalIqClient
 import com.sonatype.nexus.api.iq.internal.InternalIqClientBuilder
 import com.sonatype.nexus.api.iq.scan.ScanResult
+
 import org.sonatype.nexus.ci.config.GlobalNexusConfiguration
 import org.sonatype.nexus.ci.config.NxiqConfiguration
 import org.sonatype.nexus.ci.config.NxrmConfiguration

--- a/src/test/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorTest.groovy
+++ b/src/test/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorTest.groovy
@@ -33,10 +33,12 @@ import hudson.model.TaskListener
 import hudson.remoting.Channel
 import org.slf4j.Logger
 import spock.lang.Specification
+import spock.util.mop.ConfineMetaClassChanges
 
 import static TestDataGenerators.createAlert
 import static java.util.Collections.emptyList
 
+@ConfineMetaClassChanges([IqClientFactory])
 class IqPolicyEvaluatorTest
     extends Specification
 {

--- a/src/test/java/org/sonatype/nexus/ci/iq/RemoteScannerTest.groovy
+++ b/src/test/java/org/sonatype/nexus/ci/iq/RemoteScannerTest.groovy
@@ -22,7 +22,9 @@ import jenkins.model.Jenkins
 import org.codehaus.plexus.util.DirectoryScanner
 import org.slf4j.Logger
 import spock.lang.Specification
+import spock.util.mop.ConfineMetaClassChanges
 
+@ConfineMetaClassChanges([IqClientFactory])
 class RemoteScannerTest
     extends Specification
 {

--- a/src/test/java/org/sonatype/nexus/ci/util/IqUtilTest.groovy
+++ b/src/test/java/org/sonatype/nexus/ci/util/IqUtilTest.groovy
@@ -26,7 +26,9 @@ import hudson.util.FormValidation.Kind
 import org.junit.Rule
 import org.jvnet.hudson.test.JenkinsRule
 import spock.lang.Specification
+import spock.util.mop.ConfineMetaClassChanges
 
+@ConfineMetaClassChanges([IqClientFactory])
 class IqUtilTest
     extends Specification
 {


### PR DESCRIPTION
- When mocking classes ensure their implementation is not expected from other tests
- Confine meta changes if implementation used elsewhere