### PR TITLE
CLM-9174 Java 9 bytecode hashing support.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
       <dependency>
         <groupId>com.sonatype.nexus</groupId>
         <artifactId>nexus-platform-api</artifactId>
-        <version>1.7.20170929-121951.293626c</version>
+        <version>1.8.20171117-181703.7fbe604</version>
         <classifier>internal</classifier>
       </dependency>
 


### PR DESCRIPTION
Updated nexus-platform-api to 1.8.20171117-181703.7fbe604 to include support for java 9 bytecode hashing.

https://issues.sonatype.org/browse/CLM-9174
https://jenkins.zion.aws.s/job/integrations/job/tneer-nexus-platform-plugin-feature/job/CLM-9174_update_java9_hashing/