### PR TITLE
[JEP-200] POM updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,8 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.22</version>
+    <version>3.2</version>
+    <relativePath />
   </parent>
 
   <groupId>org.sonatype.nexus.ci</groupId>
@@ -52,11 +53,11 @@
   </developers>
 
   <properties>
+    <enforcer.skip>true</enforcer.skip> <!-- TODO numerous requireUpperBoundDeps, some probably indicative of real problems -->
     <jenkins.version>2.7</jenkins.version>
-    <jenkins-test-harness.version>2.7</jenkins-test-harness.version>
     <findbugs-maven-plugin.version>3.0.2</findbugs-maven-plugin.version>
     <jvnet-localizer-plugin.version>1.23</jvnet-localizer-plugin.version>
-    <concurrency>1</concurrency>
+    <forkCount>1</forkCount>
     <java.level>7</java.level>
     <slf4j.version>1.7.7</slf4j.version>
 
@@ -89,11 +90,6 @@
         <classifier>internal</classifier>
       </dependency>
 
-      <dependency>
-        <groupId>org.jenkins-ci.main</groupId>
-        <artifactId>jenkins-core</artifactId>
-        <version>${jenkins.version}</version>
-      </dependency>
       <dependency>
         <groupId>javax.servlet</groupId>
         <artifactId>servlet-api</artifactId>
@@ -140,31 +136,6 @@
       </dependency>
 
       <dependency>
-        <groupId>org.jenkins-ci.main</groupId>
-        <artifactId>jenkins-war</artifactId>
-        <version>${jenkins.version}</version>
-        <type>war</type>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.jenkins-ci.main</groupId>
-        <artifactId>jenkins-war</artifactId>
-        <version>${jenkins.version}</version>
-        <classifier>war-for-test</classifier>
-      </dependency>
-      <dependency>
-        <groupId>org.jenkins-ci.main</groupId>
-        <artifactId>jenkins-test-harness</artifactId>
-        <version>${jenkins-test-harness.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>junit</groupId>
-        <artifactId>junit</artifactId>
-        <version>4.12</version>
-      </dependency>
-
-      <dependency>
         <groupId>cglib</groupId>
         <artifactId>cglib-nodep</artifactId>
         <version>3.2.4</version>
@@ -177,17 +148,6 @@
       <groupId>com.sonatype.nexus</groupId>
       <artifactId>nexus-platform-api</artifactId>
       <classifier>internal</classifier>
-    </dependency>
-
-    <dependency>
-      <groupId>org.jenkins-ci.main</groupId>
-      <artifactId>jenkins-core</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
-      <scope>provided</scope>
     </dependency>
 
     <dependency>
@@ -219,36 +179,6 @@
     <dependency>
       <groupId>org.spockframework</groupId>
       <artifactId>spock-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.jenkins-ci.main</groupId>
-      <artifactId>jenkins-war</artifactId>
-      <type>war</type>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.main</groupId>
-      <artifactId>jenkins-war</artifactId>
-      <classifier>war-for-test</classifier>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.main</groupId>
-      <artifactId>jenkins-test-harness</artifactId>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>junit</groupId>
-          <artifactId>junit-dep</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
 
@@ -483,7 +413,6 @@
       <id>jenkins-1.642.3</id>
       <properties>
         <jenkins.version>1.642.3</jenkins.version>
-        <jenkins-test-harness.version>1.642.3</jenkins-test-harness.version>
       </properties>
     </profile>
 


### PR DESCRIPTION
Routine POM cleanups, permitting tests to be run against newer Jenkins versions than the declared baseline.

Attempting to test against https://github.com/jenkinsci/jenkins/pull/3120, since code inspection suggests that the `RemoteScanResult.scan` field will fail to be deserialized from agents in Jenkins 2.102+. Unfortunately you appear to have no functional tests whatsoever which would build on agents; when I tried

```diff
diff --git a/src/test/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorIntegrationTest.groovy b/src/test/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorIntegrationTest.groovy
index c3be5a2..767d944 100644
--- a/src/test/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorIntegrationTest.groovy
+++ b/src/test/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorIntegrationTest.groovy
@@ -108,6 +108,7 @@ class IqPolicyEvaluatorIntegrationTest
   def 'Freestyle build (happy path)'() {
     given: 'a jenkins project'
       FreeStyleProject project = jenkins.createFreeStyleProject()
+      project.assignedNode = jenkins.createSlave()
       project.buildersList.add(new IqPolicyEvaluatorBuildStep('stage', 'app', [], false, 'cred-id'))
       configureJenkins()
```

it did not work, I suppose because you are using Java mocks rather than an actual mock (HTTP?) service, and mocks do not transfer across JVM boundaries.

I also have no idea how to test this plugin manually, and no inclination to try. The regression, if real, could most likely be corrected by creating a `src/main/resources/META-INF/hudson.remoting.ClassFilter` containing

```
com.sonatype.insight.scan.model.Scan
com.sonatype.insight.scan.model.Application
# …whatever the transitive serial closure of Scan might be
```

or by simply making the Remoting channel transfer only simpler datatypes, such as `String`, rather than relying on serialization of external libraries.

@reviewbybees