### PR TITLE
INT-601 Correct CSS loading for Jenkins v1

### DIFF
--- a/src/main/resources/org/sonatype/nexus/ci/iq/PolicyEvaluationHealthAction/summary.groovy
+++ b/src/main/resources/org/sonatype/nexus/ci/iq/PolicyEvaluationHealthAction/summary.groovy
@@ -16,12 +16,12 @@ import org.sonatype.nexus.ci.iq.Messages
 import org.sonatype.nexus.ci.iq.PolicyEvaluationHealthAction
 
 def t = namespace(lib.JenkinsTagLib)
-def l = namespace(lib.LayoutTagLib)
 
 def action = (PolicyEvaluationHealthAction) it
 
-l.css(src: "${rootURL}/plugin/nexus-jenkins-plugin/css/nexus.css")
 t.summary(icon: '/plugin/nexus-jenkins-plugin/images/48x48/nexus-iq.png') {
+  style(type: "text/css", ".nexus-jenkins-error { background: #faf3d1; border: 1px solid #eac9a9; -moz-border-radius: 3px; -webkit-border-radius: 3px; border-radius: px; padding: 0; -moz-box-shadow: 0 0 5px #ccc8b3; -webkit-box-shadow: 0 0 5px #ccc8b3; box-shadow: 0 0 5px #ccc8b3; margin: 15px; letter-spacing: normal; text-align: center }  .iq-job-main-table { margin-top: 1em; margin-left: 1em; }  .iq-job-main-table img { margin-right: 0 !important; }  .iq-chiclet { display:inline-block; width:25px; text-align:center; border-radius:5px; -moz-border-radius:5px; color:white; margin-right: 5px; }  .iq-chiclet.critical { background-color: #bc012f; }  .iq-chiclet.severe { background-color: #f4861d; }  .iq-chiclet.moderate { background-color: #f5c648; }")
+
   a(href: "${action.getUrlName()}", Messages.IqPolicyEvaluation_ReportName())
   br()
   img(src: "${rootURL}/plugin/nexus-jenkins-plugin/images/16x16/governance-badge.png")

--- a/src/main/resources/org/sonatype/nexus/ci/iq/PolicyEvaluationHealthAction/summary.groovy
+++ b/src/main/resources/org/sonatype/nexus/ci/iq/PolicyEvaluationHealthAction/summary.groovy
@@ -20,31 +20,8 @@ def t = namespace(lib.JenkinsTagLib)
 def action = (PolicyEvaluationHealthAction) it
 
 t.summary(icon: '/plugin/nexus-jenkins-plugin/images/48x48/nexus-iq.png') {
+  // Inline the iq-chiclet css here for Jenkins v1 which does not support the css tag.
   style(type: 'text/css', """
-        .nexus-jenkins-error {
-          background: #faf3d1;
-          border: 1px solid #eac9a9;
-          -moz-border-radius: 3px;
-          -webkit-border-radius: 3px;
-          border-radius: px;
-          padding: 0;
-          -moz-box-shadow: 0 0 5px #ccc8b3;
-          -webkit-box-shadow: 0 0 5px #ccc8b3;
-          box-shadow: 0 0 5px #ccc8b3;
-          margin: 15px;
-          letter-spacing: normal;
-          text-align: center
-        }
-        
-        .iq-job-main-table {
-          margin-top: 1em;
-          margin-left: 1em;
-        }
-        
-        .iq-job-main-table img {
-          margin-right: 0 !important;
-        }
-        
         .iq-chiclet {
           display:inline-block;
           width:25px;

--- a/src/main/resources/org/sonatype/nexus/ci/iq/PolicyEvaluationHealthAction/summary.groovy
+++ b/src/main/resources/org/sonatype/nexus/ci/iq/PolicyEvaluationHealthAction/summary.groovy
@@ -20,8 +20,53 @@ def t = namespace(lib.JenkinsTagLib)
 def action = (PolicyEvaluationHealthAction) it
 
 t.summary(icon: '/plugin/nexus-jenkins-plugin/images/48x48/nexus-iq.png') {
-  style(type: "text/css", ".nexus-jenkins-error { background: #faf3d1; border: 1px solid #eac9a9; -moz-border-radius: 3px; -webkit-border-radius: 3px; border-radius: px; padding: 0; -moz-box-shadow: 0 0 5px #ccc8b3; -webkit-box-shadow: 0 0 5px #ccc8b3; box-shadow: 0 0 5px #ccc8b3; margin: 15px; letter-spacing: normal; text-align: center }  .iq-job-main-table { margin-top: 1em; margin-left: 1em; }  .iq-job-main-table img { margin-right: 0 !important; }  .iq-chiclet { display:inline-block; width:25px; text-align:center; border-radius:5px; -moz-border-radius:5px; color:white; margin-right: 5px; }  .iq-chiclet.critical { background-color: #bc012f; }  .iq-chiclet.severe { background-color: #f4861d; }  .iq-chiclet.moderate { background-color: #f5c648; }")
-
+  style(type: 'text/css', """
+        .nexus-jenkins-error {
+          background: #faf3d1;
+          border: 1px solid #eac9a9;
+          -moz-border-radius: 3px;
+          -webkit-border-radius: 3px;
+          border-radius: px;
+          padding: 0;
+          -moz-box-shadow: 0 0 5px #ccc8b3;
+          -webkit-box-shadow: 0 0 5px #ccc8b3;
+          box-shadow: 0 0 5px #ccc8b3;
+          margin: 15px;
+          letter-spacing: normal;
+          text-align: center
+        }
+        
+        .iq-job-main-table {
+          margin-top: 1em;
+          margin-left: 1em;
+        }
+        
+        .iq-job-main-table img {
+          margin-right: 0 !important;
+        }
+        
+        .iq-chiclet {
+          display:inline-block;
+          width:25px;
+          text-align:center;
+          border-radius:5px;
+          -moz-border-radius:5px;
+          color:white;
+          margin-right: 5px;
+        }
+        
+        .iq-chiclet.critical {
+          background-color: #bc012f;
+        }
+        
+        .iq-chiclet.severe {
+          background-color: #f4861d;
+        }
+        
+        .iq-chiclet.moderate {
+          background-color: #f5c648;
+        }
+      """)
   a(href: "${action.getUrlName()}", Messages.IqPolicyEvaluation_ReportName())
   br()
   img(src: "${rootURL}/plugin/nexus-jenkins-plugin/images/16x16/governance-badge.png")

--- a/src/main/resources/org/sonatype/nexus/ci/iq/PolicyEvaluationHealthAction/summary.groovy
+++ b/src/main/resources/org/sonatype/nexus/ci/iq/PolicyEvaluationHealthAction/summary.groovy
@@ -20,7 +20,7 @@ def l = namespace(lib.LayoutTagLib)
 
 def action = (PolicyEvaluationHealthAction) it
 
-l.css(src: '/plugin/nexus-jenkins-plugin/css/nexus.css')
+l.css(src: "${rootURL}/plugin/nexus-jenkins-plugin/css/nexus.css")
 t.summary(icon: '/plugin/nexus-jenkins-plugin/images/48x48/nexus-iq.png') {
   a(href: "${action.getUrlName()}", Messages.IqPolicyEvaluation_ReportName())
   br()

--- a/src/main/resources/org/sonatype/nexus/ci/iq/PolicyEvaluationProjectAction/jobMain.groovy
+++ b/src/main/resources/org/sonatype/nexus/ci/iq/PolicyEvaluationProjectAction/jobMain.groovy
@@ -24,31 +24,8 @@ def action = projectAction.getJob().lastCompletedBuild.getAction(PolicyEvaluatio
 if (action) {
   table(class: 'iq-job-main-table') {
     t.summary(icon: '/plugin/nexus-jenkins-plugin/images/48x48/nexus-iq.png') {
+      // Inline the iq-chiclet css here for Jenkins v1 which does not support the css tag.
       style(type: 'text/css', """
-            .nexus-jenkins-error {
-              background: #faf3d1;
-              border: 1px solid #eac9a9;
-              -moz-border-radius: 3px;
-              -webkit-border-radius: 3px;
-              border-radius: px;
-              padding: 0;
-              -moz-box-shadow: 0 0 5px #ccc8b3;
-              -webkit-box-shadow: 0 0 5px #ccc8b3;
-              box-shadow: 0 0 5px #ccc8b3;
-              margin: 15px;
-              letter-spacing: normal;
-              text-align: center
-            }
-            
-            .iq-job-main-table {
-              margin-top: 1em;
-              margin-left: 1em;
-            }
-            
-            .iq-job-main-table img {
-              margin-right: 0 !important;
-            }
-            
             .iq-chiclet {
               display:inline-block;
               width:25px;

--- a/src/main/resources/org/sonatype/nexus/ci/iq/PolicyEvaluationProjectAction/jobMain.groovy
+++ b/src/main/resources/org/sonatype/nexus/ci/iq/PolicyEvaluationProjectAction/jobMain.groovy
@@ -17,15 +17,14 @@ import org.sonatype.nexus.ci.iq.PolicyEvaluationHealthAction
 import org.sonatype.nexus.ci.iq.PolicyEvaluationProjectAction
 
 def t = namespace(lib.JenkinsTagLib)
-def l = namespace(lib.LayoutTagLib)
 
 def projectAction = (PolicyEvaluationProjectAction) it
 def action = projectAction.getJob().lastCompletedBuild.getAction(PolicyEvaluationHealthAction.class)
 
 if (action) {
-  l.css(src: "${rootURL}/plugin/nexus-jenkins-plugin/css/nexus.css")
   table(class: 'iq-job-main-table') {
     t.summary(icon: '/plugin/nexus-jenkins-plugin/images/48x48/nexus-iq.png') {
+      style(type: "text/css", ".nexus-jenkins-error { background: #faf3d1; border: 1px solid #eac9a9; -moz-border-radius: 3px; -webkit-border-radius: 3px; border-radius: px; padding: 0; -moz-box-shadow: 0 0 5px #ccc8b3; -webkit-box-shadow: 0 0 5px #ccc8b3; box-shadow: 0 0 5px #ccc8b3; margin: 15px; letter-spacing: normal; text-align: center }  .iq-job-main-table { margin-top: 1em; margin-left: 1em; }  .iq-job-main-table img { margin-right: 0 !important; }  .iq-chiclet { display:inline-block; width:25px; text-align:center; border-radius:5px; -moz-border-radius:5px; color:white; margin-right: 5px; }  .iq-chiclet.critical { background-color: #bc012f; }  .iq-chiclet.severe { background-color: #f4861d; }  .iq-chiclet.moderate { background-color: #f5c648; }")
       a(href: "lastCompletedBuild/${action.getUrlName()}", Messages.IqPolicyEvaluation_LatestReportName())
       br()
       img(src: "${rootURL}/plugin/nexus-jenkins-plugin/images/16x16/governance-badge.png")

--- a/src/main/resources/org/sonatype/nexus/ci/iq/PolicyEvaluationProjectAction/jobMain.groovy
+++ b/src/main/resources/org/sonatype/nexus/ci/iq/PolicyEvaluationProjectAction/jobMain.groovy
@@ -23,7 +23,7 @@ def projectAction = (PolicyEvaluationProjectAction) it
 def action = projectAction.getJob().lastCompletedBuild.getAction(PolicyEvaluationHealthAction.class)
 
 if (action) {
-  l.css(src: '/plugin/nexus-jenkins-plugin/css/nexus.css')
+  l.css(src: "${rootURL}/plugin/nexus-jenkins-plugin/css/nexus.css")
   table(class: 'iq-job-main-table') {
     t.summary(icon: '/plugin/nexus-jenkins-plugin/images/48x48/nexus-iq.png') {
       a(href: "lastCompletedBuild/${action.getUrlName()}", Messages.IqPolicyEvaluation_LatestReportName())

--- a/src/main/resources/org/sonatype/nexus/ci/iq/PolicyEvaluationProjectAction/jobMain.groovy
+++ b/src/main/resources/org/sonatype/nexus/ci/iq/PolicyEvaluationProjectAction/jobMain.groovy
@@ -24,7 +24,53 @@ def action = projectAction.getJob().lastCompletedBuild.getAction(PolicyEvaluatio
 if (action) {
   table(class: 'iq-job-main-table') {
     t.summary(icon: '/plugin/nexus-jenkins-plugin/images/48x48/nexus-iq.png') {
-      style(type: "text/css", ".nexus-jenkins-error { background: #faf3d1; border: 1px solid #eac9a9; -moz-border-radius: 3px; -webkit-border-radius: 3px; border-radius: px; padding: 0; -moz-box-shadow: 0 0 5px #ccc8b3; -webkit-box-shadow: 0 0 5px #ccc8b3; box-shadow: 0 0 5px #ccc8b3; margin: 15px; letter-spacing: normal; text-align: center }  .iq-job-main-table { margin-top: 1em; margin-left: 1em; }  .iq-job-main-table img { margin-right: 0 !important; }  .iq-chiclet { display:inline-block; width:25px; text-align:center; border-radius:5px; -moz-border-radius:5px; color:white; margin-right: 5px; }  .iq-chiclet.critical { background-color: #bc012f; }  .iq-chiclet.severe { background-color: #f4861d; }  .iq-chiclet.moderate { background-color: #f5c648; }")
+      style(type: 'text/css', """
+            .nexus-jenkins-error {
+              background: #faf3d1;
+              border: 1px solid #eac9a9;
+              -moz-border-radius: 3px;
+              -webkit-border-radius: 3px;
+              border-radius: px;
+              padding: 0;
+              -moz-box-shadow: 0 0 5px #ccc8b3;
+              -webkit-box-shadow: 0 0 5px #ccc8b3;
+              box-shadow: 0 0 5px #ccc8b3;
+              margin: 15px;
+              letter-spacing: normal;
+              text-align: center
+            }
+            
+            .iq-job-main-table {
+              margin-top: 1em;
+              margin-left: 1em;
+            }
+            
+            .iq-job-main-table img {
+              margin-right: 0 !important;
+            }
+            
+            .iq-chiclet {
+              display:inline-block;
+              width:25px;
+              text-align:center;
+              border-radius:5px;
+              -moz-border-radius:5px;
+              color:white;
+              margin-right: 5px;
+            }
+            
+            .iq-chiclet.critical {
+              background-color: #bc012f;
+            }
+            
+            .iq-chiclet.severe {
+              background-color: #f4861d;
+            }
+            
+            .iq-chiclet.moderate {
+              background-color: #f5c648;
+            }
+          """)
       a(href: "lastCompletedBuild/${action.getUrlName()}", Messages.IqPolicyEvaluation_LatestReportName())
       br()
       img(src: "${rootURL}/plugin/nexus-jenkins-plugin/images/16x16/governance-badge.png")

--- a/src/main/webapp/css/nexus.css
+++ b/src/main/webapp/css/nexus.css
@@ -33,25 +33,3 @@
 .iq-job-main-table img {
   margin-right: 0 !important;
 }
-
-.iq-chiclet {
-  display:inline-block;
-  width:25px;
-  text-align:center;
-  border-radius:5px;
-  -moz-border-radius:5px;
-  color:white;
-  margin-right: 5px;
-}
-
-.iq-chiclet.critical {
-  background-color: #bc012f;
-}
-
-.iq-chiclet.severe {
-  background-color: #f4861d;
-}
-
-.iq-chiclet.moderate {
-  background-color: #f5c648;
-}


### PR DESCRIPTION
#### Description
The css tag is not available in jenkins versions prior to 2.0. Allow the css to load for jenkins v1+ for policy violations on the job main and summary pages.

Tested with jenkins-1.642.18.1 and jenkins.2.107.3.

#### Links
JIRA:   https://issues.sonatype.org/browse/INT-601

CI: https://jenkins.zion.aws.s/job/integrations/job/jenkins/job/nexus-platform-plugin-feature/job/INT-601-css-chiclets/2

#### Screencast
https://youtu.be/A3q_t_tVc2c
