### PR TITLE
NEXUS-17660: support move by search from pipeline

### DIFF
--- a/src/main/java/org/sonatype/nexus/ci/nxrm/v3/MoveComponentsStep.java
+++ b/src/main/java/org/sonatype/nexus/ci/nxrm/v3/MoveComponentsStep.java
@@ -29,7 +29,6 @@ import org.sonatype.nexus.ci.util.FormUtil;
 import org.sonatype.nexus.ci.util.Nxrm3Util;
 import org.sonatype.nexus.ci.util.NxrmUtil;
 
-import com.google.common.collect.Maps;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.Launcher;
@@ -93,7 +92,10 @@ public class MoveComponentsStep
   @DataBoundSetter
   public void setSearch(final Map<String, String> search) {
     this.search.clear();
-    this.search.putAll(search);
+
+    if (search != null) {
+      this.search.putAll(search);
+    }
   }
 
   @CheckForNull

--- a/src/test/java/org/sonatype/nexus/ci/nxrm/v3/MoveComponentsStepTest.groovy
+++ b/src/test/java/org/sonatype/nexus/ci/nxrm/v3/MoveComponentsStepTest.groovy
@@ -71,27 +71,27 @@ class MoveComponentsStepTest
       def client = Mock(RepositoryManagerV3Client.class)
       def repositories = [
           [
-              name            : 'Maven Releases',
-              format          : 'maven2',
-              type            : 'hosted',
+              name: 'Maven Releases',
+              format: 'maven2',
+              type: 'hosted',
               repositoryPolicy: 'Release'
           ],
           [
-              name            : 'Maven 1 Releases',
-              format          : 'maven1',
-              type            : 'proxy',
+              name: 'Maven 1 Releases',
+              format: 'maven1',
+              type: 'proxy',
               repositoryPolicy: 'Release'
           ],
           [
-              name            : 'Maven Snapshots',
-              format          : 'maven2',
-              type            : 'hosted',
+              name: 'Maven Snapshots',
+              format: 'maven2',
+              type: 'hosted',
               repositoryPolicy: 'Snapshot'
           ],
           [
-              name            : 'Maven Proxy',
-              format          : 'maven2',
-              type            : 'proxy',
+              name: 'Maven Proxy',
+              format: 'maven2',
+              type: 'proxy',
               repositoryPolicy: 'Release'
           ]
       ]
@@ -180,11 +180,11 @@ class MoveComponentsStepTest
       //We set up the workflow with 2 move steps...we should only see the first one called
       project.setDefinition(new CpsFlowDefinition(
           "node { " +
-              "\nmoveComponents destination: '" + destination + "', nexusInstanceId: '" + instance + "', tagName: '" +
+          "\nmoveComponents destination: '" + destination + "', nexusInstanceId: '" + instance +"', tagName: '" +
               tagName + "'" +
-              "\nmoveComponents destination: '" + destination + "', nexusInstanceId: '" + instance + "', tagName: '" +
+          "\nmoveComponents destination: '" + destination + "', nexusInstanceId: '" + instance +"', tagName: '" +
               tagName + "'" +
-              "}"))
+          "}"))
 
       GroovyMock(RepositoryManagerClientUtil.class, global: true)
       RepositoryManagerClientUtil.nexus3Client(config.serverUrl, config.credentialsId) >> nxrm3Client
@@ -202,7 +202,7 @@ class MoveComponentsStepTest
   def 'it fails attempting to get an nxrm3 client with invalid id'() {
     setup:
       def project = getProject('invalidclient', 'maven-releases', 'foo',
-          { throw new RepositoryManagerException("localhost not found") })
+          { throw new RepositoryManagerException("localhost not found") } )
 
     when:
       def build = project.scheduleBuild2(0).get()
@@ -225,17 +225,17 @@ class MoveComponentsStepTest
   }
 
   def 'it fails to complete a move operation based on a tag as a workflow'() {
-    setup:
-      def project = getWorkflowProject('localhost', 'maven-releases', 'foo'
-          , { throw new RepositoryManagerException("Move failed") })
+      setup:
+        def project = getWorkflowProject('localhost', 'maven-releases', 'foo'
+            , { throw new RepositoryManagerException("Move failed") })
 
-    when:
-      def build = project.scheduleBuild2(0).get()
+      when:
+        def build = project.scheduleBuild2(0).get()
 
-    then:
-      jenkinsRule.assertBuildStatus(Result.FAILURE, build)
-      jenkinsRule.assertLogContains("Failing build due to: Move failed", build)
-  }
+      then:
+        jenkinsRule.assertBuildStatus(Result.FAILURE, build)
+        jenkinsRule.assertLogContains("Failing build due to: Move failed", build)
+    }
 
   @Unroll
   def 'it fails due to missing parameter in workflow dsl - #missingParam'(stepArgs, missingParam, expectedLogMsg) {

--- a/src/test/java/org/sonatype/nexus/ci/nxrm/v3/MoveComponentsStepTest.groovy
+++ b/src/test/java/org/sonatype/nexus/ci/nxrm/v3/MoveComponentsStepTest.groovy
@@ -12,8 +12,6 @@
  */
 package org.sonatype.nexus.ci.nxrm.v3
 
-import javax.annotation.CheckForNull
-
 import com.sonatype.nexus.api.exception.RepositoryManagerException
 import com.sonatype.nexus.api.repository.v3.ComponentInfo
 import com.sonatype.nexus.api.repository.v3.RepositoryManagerV3Client


### PR DESCRIPTION
https://issues.sonatype.org/browse/NEXUS-17660
https://jenkins.zion.aws.s/job/integrations/job/jenkins/job/sonatype-nexus-platform-plugin-feature/job/NEXUS-17660_promote_by_search/

Allows users to specify search parameters for the `moveComponents` step to allow finer grained filtering of components. This will allow tags that apply to multiple components spanning multiple formats to be manipulated without needing separate tags