### PR TITLE
Add grandfathered count to Jenkins summary report CLM-10490 CLM-10612

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
       <dependency>
         <groupId>com.sonatype.nexus</groupId>
         <artifactId>nexus-platform-api</artifactId>
-        <version>3.2.20180720-113856.04ab436</version>
+        <version>3.2-SNAPSHOT</version>
         <classifier>internal</classifier>
       </dependency>
 

--- a/src/main/java/org/sonatype/nexus/ci/iq/PolicyEvaluationHealthAction.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/iq/PolicyEvaluationHealthAction.groovy
@@ -38,6 +38,8 @@ class PolicyEvaluationHealthAction
   private final int severeComponentCount
 
   private final int moderateComponentCount
+  
+  private final int grandfatheredPolicyViolationCount
 
   PolicyEvaluationHealthAction(final Run run,
                                       final ApplicationPolicyEvaluation policyEvaluationResult)
@@ -48,6 +50,7 @@ class PolicyEvaluationHealthAction
     this.criticalComponentCount = policyEvaluationResult.criticalComponentCount
     this.severeComponentCount = policyEvaluationResult.severeComponentCount
     this.moderateComponentCount = policyEvaluationResult.moderateComponentCount
+    this.grandfatheredPolicyViolationCount = policyEvaluationResult.grandfatheredPolicyViolationCount
   }
 
   int getBuildNumber() {
@@ -64,6 +67,10 @@ class PolicyEvaluationHealthAction
 
   int getModerateComponentCount() {
     return moderateComponentCount
+  }
+
+  int getGrandfatheredPolicyViolationCount() {
+    return grandfatheredPolicyViolationCount
   }
 
   @Override

--- a/src/main/resources/org/sonatype/nexus/ci/iq/Messages.properties
+++ b/src/main/resources/org/sonatype/nexus/ci/iq/Messages.properties
@@ -37,6 +37,7 @@ IqPolicyEvaluation.EvaluationWarning=IQ Server evaluation of application {0} det
 IqPolicyEvaluation.ReportName=Application Composition Report
 IqPolicyEvaluation.LatestReportName=Latest Application Composition Report
 IqPolicyEvaluation.NoViolations=No Violations
+IqPolicyEvaluation.NumberGrandfathered={0} grandfathered
 
 PolicyFailureMessageFormatter.PolicyFailing=Nexus IQ reports policy failing due to {0}
 PolicyFailureMessageFormatter.PolicyWarning=Nexus IQ reports policy warning due to {0}

--- a/src/main/resources/org/sonatype/nexus/ci/iq/PolicyEvaluationHealthAction/summary.groovy
+++ b/src/main/resources/org/sonatype/nexus/ci/iq/PolicyEvaluationHealthAction/summary.groovy
@@ -59,4 +59,5 @@ t.summary(icon: '/plugin/nexus-jenkins-plugin/images/48x48/nexus-iq.png') {
   if (!action.criticalComponentCount && !action.severeComponentCount && !action.moderateComponentCount) {
     span(Messages.IqPolicyEvaluation_NoViolations())
   }
+  span(Messages.IqPolicyEvaluation_NumberGrandfathered(action.grandfatheredPolicyViolationCount))
 }

--- a/src/main/resources/org/sonatype/nexus/ci/iq/PolicyEvaluationHealthAction/summary.groovy
+++ b/src/main/resources/org/sonatype/nexus/ci/iq/PolicyEvaluationHealthAction/summary.groovy
@@ -43,6 +43,10 @@ t.summary(icon: '/plugin/nexus-jenkins-plugin/images/48x48/nexus-iq.png') {
         .iq-chiclet.moderate {
           background-color: #f5c648;
         }
+        
+        .iq-chiclet-message {
+          margin-right: 5px;
+        }
       """)
   a(href: "${action.getUrlName()}", Messages.IqPolicyEvaluation_ReportName())
   br()
@@ -57,7 +61,7 @@ t.summary(icon: '/plugin/nexus-jenkins-plugin/images/48x48/nexus-iq.png') {
     span(class: 'iq-chiclet moderate', action.moderateComponentCount)
   }
   if (!action.criticalComponentCount && !action.severeComponentCount && !action.moderateComponentCount) {
-    span(Messages.IqPolicyEvaluation_NoViolations())
+    span(class: 'iq-chiclet-message', Messages.IqPolicyEvaluation_NoViolations())
   }
-  span(Messages.IqPolicyEvaluation_NumberGrandfathered(action.grandfatheredPolicyViolationCount))
+  span(class: 'iq-chiclet-message', Messages.IqPolicyEvaluation_NumberGrandfathered(action.grandfatheredPolicyViolationCount))
 }

--- a/src/main/resources/org/sonatype/nexus/ci/iq/PolicyEvaluationProjectAction/jobMain.groovy
+++ b/src/main/resources/org/sonatype/nexus/ci/iq/PolicyEvaluationProjectAction/jobMain.groovy
@@ -63,6 +63,7 @@ if (action) {
       if (!action.criticalComponentCount && !action.severeComponentCount && !action.moderateComponentCount) {
         span(Messages.IqPolicyEvaluation_NoViolations())
       }
+      span(Messages.IqPolicyEvaluation_NumberGrandfathered(action.grandfatheredPolicyViolationCount))
     }
   }
 }

--- a/src/main/resources/org/sonatype/nexus/ci/iq/PolicyEvaluationProjectAction/jobMain.groovy
+++ b/src/main/resources/org/sonatype/nexus/ci/iq/PolicyEvaluationProjectAction/jobMain.groovy
@@ -47,6 +47,10 @@ if (action) {
             .iq-chiclet.moderate {
               background-color: #f5c648;
             }
+            
+            .iq-chiclet-message {
+              margin-right: 5px;
+            }
           """)
       a(href: "lastCompletedBuild/${action.getUrlName()}", Messages.IqPolicyEvaluation_LatestReportName())
       br()
@@ -61,9 +65,9 @@ if (action) {
         span(class: 'iq-chiclet moderate', action.moderateComponentCount)
       }
       if (!action.criticalComponentCount && !action.severeComponentCount && !action.moderateComponentCount) {
-        span(Messages.IqPolicyEvaluation_NoViolations())
+        span(class: 'iq-chiclet-message', Messages.IqPolicyEvaluation_NoViolations())
       }
-      span(Messages.IqPolicyEvaluation_NumberGrandfathered(action.grandfatheredPolicyViolationCount))
+      span(class: 'iq-chiclet-message', Messages.IqPolicyEvaluation_NumberGrandfathered(action.grandfatheredPolicyViolationCount))
     }
   }
 }

--- a/src/test/java/org/sonatype/nexus/ci/config/ComToOrgMigratorIntegrationTest.groovy
+++ b/src/test/java/org/sonatype/nexus/ci/config/ComToOrgMigratorIntegrationTest.groovy
@@ -99,7 +99,7 @@ class ComToOrgMigratorIntegrationTest
     then: 'the application is scanned and evaluated'
       1 * iqClient.verifyOrCreateApplication(*_) >> true
       1 * iqClient.scan(*_) >> new ScanResult(new Scan(), File.createTempFile('dummy-scan', '.xml.gz'))
-      1 * iqClient.evaluateApplication('sample-app', 'build', _) >> new ApplicationPolicyEvaluation(0, 1, 2, 3, [],
+      1 * iqClient.evaluateApplication('sample-app', 'build', _) >> new ApplicationPolicyEvaluation(0, 1, 2, 3, 0, [],
           'http://server/link/to/report')
 
     then: 'the return code is successful'
@@ -122,7 +122,7 @@ class ComToOrgMigratorIntegrationTest
     then: 'the application is scanned and evaluated'
       1 * iqClient.verifyOrCreateApplication(*_) >> true
       1 * iqClient.scan(*_) >> new ScanResult(new Scan(), File.createTempFile('dummy-scan', '.xml.gz'))
-      1 * iqClient.evaluateApplication('sample-app', 'build', _) >> new ApplicationPolicyEvaluation(0, 1, 2, 3, [],
+      1 * iqClient.evaluateApplication('sample-app', 'build', _) >> new ApplicationPolicyEvaluation(0, 1, 2, 3, 0, [],
           'http://server/link/to/report')
 
     then: 'the expected result is returned'

--- a/src/test/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorIntegrationTest.groovy
+++ b/src/test/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorIntegrationTest.groovy
@@ -93,7 +93,7 @@ class IqPolicyEvaluatorIntegrationTest
       1 * iqClient.verifyOrCreateApplication(*_) >> true
       1 * iqClient.scan(*_) >> new ScanResult(new Scan(), File.createTempFile('dummy-scan', '.xml.gz'))
       1 * iqClient.evaluateApplication(*_) >>
-          new ApplicationPolicyEvaluation(0, 1, 2, 3, [], 'http://server/link/to/report')
+          new ApplicationPolicyEvaluation(0, 1, 2, 3, 0, [], 'http://server/link/to/report')
 
     and: 'the build is successful'
       jenkins.assertBuildStatusSuccess(build)
@@ -122,7 +122,7 @@ class IqPolicyEvaluatorIntegrationTest
     then: 'the application is scanned and evaluated'
       1 * iqClient.verifyOrCreateApplication(*_) >> true
       1 * iqClient.scan(*_) >> new ScanResult(new Scan(), File.createTempFile('dummy-scan', '.xml.gz'))
-      1 * iqClient.evaluateApplication(*_) >> new ApplicationPolicyEvaluation(0, 1, 2, 3, [],
+      1 * iqClient.evaluateApplication(*_) >> new ApplicationPolicyEvaluation(0, 1, 2, 3, 0, [],
           'http://server/link/to/report')
 
     then: 'the expected result is returned'
@@ -149,7 +149,7 @@ class IqPolicyEvaluatorIntegrationTest
     then: 'the application is scanned and evaluated'
       1 * iqClient.verifyOrCreateApplication(*_) >> true
       1 * iqClient.scan(*_) >> new ScanResult(new Scan(), File.createTempFile('dummy-scan', '.xml.gz'))
-      1 * iqClient.evaluateApplication(*_) >> new ApplicationPolicyEvaluation(0, 1, 2, 3, [],
+      1 * iqClient.evaluateApplication(*_) >> new ApplicationPolicyEvaluation(0, 1, 2, 3, 0, [],
           'http://server/link/to/report')
 
     then: 'the return code is successful'
@@ -318,7 +318,7 @@ class IqPolicyEvaluatorIntegrationTest
     then: 'the application is scanned and evaluated'
       1 * iqClient.verifyOrCreateApplication(*_) >> true
       1 * iqClient.scan(*_) >> new ScanResult(new Scan(), File.createTempFile('dummy-scan', '.xml.gz'))
-      1 * iqClient.evaluateApplication(*_) >> new ApplicationPolicyEvaluation(0, 1, 2, 3,
+      1 * iqClient.evaluateApplication(*_) >> new ApplicationPolicyEvaluation(0, 1, 2, 3, 0,
           [createAlert(Action.ID_FAIL)], 'http://server/link/to/report')
 
     and: 'the build fails'
@@ -356,7 +356,7 @@ class IqPolicyEvaluatorIntegrationTest
     then: 'the application is scanned and evaluated'
       1 * iqClient.verifyOrCreateApplication(*_) >> true
       1 * iqClient.scan(*_) >> new ScanResult(new Scan(), File.createTempFile('dummy-scan', '.xml.gz'))
-      1 * iqClient.evaluateApplication(*_) >> new ApplicationPolicyEvaluation(0, 1, 2, 3,
+      1 * iqClient.evaluateApplication(*_) >> new ApplicationPolicyEvaluation(0, 1, 2, 3, 0,
           [createAlert(Action.ID_FAIL)], 'http://server/link/to/report')
 
     and: 'the build fails'
@@ -384,7 +384,7 @@ class IqPolicyEvaluatorIntegrationTest
     then: 'the application is scanned and evaluated'
       1 * iqClient.verifyOrCreateApplication(*_) >> true
       1 * iqClient.scan(*_) >> new ScanResult(new Scan(), File.createTempFile('dummy-scan', '.xml.gz'))
-      1 * iqClient.evaluateApplication(*_) >> new ApplicationPolicyEvaluation(0, 1, 2, 3,
+      1 * iqClient.evaluateApplication(*_) >> new ApplicationPolicyEvaluation(0, 1, 2, 3, 0,
           [createAlert(Action.ID_FAIL)], 'http://server/link/to/report')
 
     then: 'the build fails'

--- a/src/test/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorTest.groovy
+++ b/src/test/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorTest.groovy
@@ -76,7 +76,7 @@ class IqPolicyEvaluatorTest
     NxiqConfiguration.serverUrl >> URI.create("http://server/path")
     NxiqConfiguration.credentialsId >> '123-cred-456'
     GlobalNexusConfiguration.instanceId >> 'instance-id'
-    iqClient.evaluateApplication("appId", "stage", _) >> new ApplicationPolicyEvaluation(0, 0, 0, 0, [],
+    iqClient.evaluateApplication("appId", "stage", _) >> new ApplicationPolicyEvaluation(0, 0, 0, 0, 0, [],
         reportUrl)
     IqClientFactory.getIqClient(*_) >> iqClient
     remoteScanResult.copyToLocalScanResult() >> scanResult
@@ -88,7 +88,7 @@ class IqPolicyEvaluatorTest
     setup:
       def buildStep = new IqPolicyEvaluatorBuildStep("stage", new SelectedApplication('appId'), [new ScanPattern("*.jar")], [],
           false, null)
-      def evaluationResult = new ApplicationPolicyEvaluation(0, 0, 0, 0, emptyList(), reportUrl)
+      def evaluationResult = new ApplicationPolicyEvaluation(0, 0, 0, 0, 0, emptyList(), reportUrl)
       def remoteScanner = Mock(RemoteScanner)
 
     when:
@@ -283,7 +283,7 @@ class IqPolicyEvaluatorTest
     then:
       1 * iqClient.verifyOrCreateApplication(*_) >> true
       1 * iqClient.evaluateApplication('appId', 'stage', scanResult) >>
-          new ApplicationPolicyEvaluation(0, 0, 0, 0, alerts, reportUrl)
+          new ApplicationPolicyEvaluation(0, 0, 0, 0, 0, alerts, reportUrl)
       1 * run.setResult(buildResult)
 
     where:
@@ -297,7 +297,7 @@ class IqPolicyEvaluatorTest
     setup:
       def buildStep = new IqPolicyEvaluatorBuildStep('stage', new SelectedApplication('appId'), [new ScanPattern('*.jar')], [],
           false, '131-cred')
-      def policyEvaluation = new ApplicationPolicyEvaluation(0, 0, 0, 0,
+      def policyEvaluation = new ApplicationPolicyEvaluation(0, 0, 0, 0, 0,
           [new PolicyAlert(null, [new Action(Action.ID_FAIL)])], reportUrl)
 
     when:
@@ -329,7 +329,7 @@ class IqPolicyEvaluatorTest
     then:
       1 * iqClient.verifyOrCreateApplication(*_) >> true
       1 * iqClient.evaluateApplication('appId', 'stage', scanResult) >>
-          new ApplicationPolicyEvaluation(0, 1, 2, 3, [new PolicyAlert(trigger, [new Action(Action.ID_FAIL)])],
+          new ApplicationPolicyEvaluation(0, 1, 2, 3, 0, [new PolicyAlert(trigger, [new Action(Action.ID_FAIL)])],
               reportUrl)
 
     and:
@@ -356,7 +356,7 @@ class IqPolicyEvaluatorTest
     then:
       1 * iqClient.verifyOrCreateApplication(*_) >> true
       1 * iqClient.evaluateApplication('appId', 'stage', scanResult) >>
-          new ApplicationPolicyEvaluation(0, 1, 2, 3, [new PolicyAlert(trigger, [new Action(Action.ID_WARN)])],
+          new ApplicationPolicyEvaluation(0, 1, 2, 3, 0, [new PolicyAlert(trigger, [new Action(Action.ID_WARN)])],
               reportUrl)
       1 * log.println("IQ Server evaluation of application appId detected warnings")
       1 * log.println(
@@ -379,7 +379,7 @@ class IqPolicyEvaluatorTest
     then:
       1 * iqClient.verifyOrCreateApplication(*_) >> true
       1 * iqClient.evaluateApplication('appId', 'stage', scanResult) >>
-          new ApplicationPolicyEvaluation(0, 0, 0, 0, [],
+          new ApplicationPolicyEvaluation(0, 0, 0, 0, 0, [],
               reportUrl)
       0 * log.println("WARNING: IQ Server evaluation of application appId detected warnings.")
       1 * log.println('\nThe detailed report can be viewed online at http://server/report\n' +

--- a/src/test/java/org/sonatype/nexus/ci/iq/PolicyEvaluationHealthActionTest.groovy
+++ b/src/test/java/org/sonatype/nexus/ci/iq/PolicyEvaluationHealthActionTest.groovy
@@ -25,7 +25,7 @@ class PolicyEvaluationHealthActionTest
   def 'it redirects to the application composition report'() {
     setup:
       def reportLink = 'http://localhost/reportLink'
-      def policyEvaluation = new ApplicationPolicyEvaluation(0, 0, 0, 0, [], reportLink)
+      def policyEvaluation = new ApplicationPolicyEvaluation(0, 0, 0, 0, 0, [], reportLink)
       def healthAction = new PolicyEvaluationHealthAction(null, policyEvaluation)
       def response = Mock(StaplerResponse)
 

--- a/src/test/java/org/sonatype/nexus/ci/iq/PolicyEvaluationHealthActionTest.groovy
+++ b/src/test/java/org/sonatype/nexus/ci/iq/PolicyEvaluationHealthActionTest.groovy
@@ -75,4 +75,26 @@ class PolicyEvaluationHealthActionTest
     then:
       buildNumber == 3
   }
+  
+  def 'it returns the correct component and grandfathered policy violation counts'() {
+    setup:
+      def reportLink = 'http://localhost/reportLink'
+      def policyEvaluation = new ApplicationPolicyEvaluation(1, 2, 3, 4, 5, [], reportLink)
+      def healthAction = new PolicyEvaluationHealthAction(null, policyEvaluation)
+      def response = Mock(StaplerResponse)
+
+    when: 'getting component and grandfathered policy violation counts'
+      def affectedComponentCount = healthAction.affectedComponentCount
+      def criticalComponentCount = healthAction.criticalComponentCount
+      def severeComponentCount = healthAction.severeComponentCount
+      def moderateComponentCount = healthAction.moderateComponentCount
+      def grandfatheredPolicyViolationCount = healthAction.grandfatheredPolicyViolationCount
+
+    then:
+      affectedComponentCount == 1
+      criticalComponentCount == 2
+      severeComponentCount == 3
+      moderateComponentCount == 4
+      grandfatheredPolicyViolationCount == 5
+  }
 }

--- a/src/test/java/org/sonatype/nexus/ci/iq/PolicyFailureMessageFormatterTest.groovy
+++ b/src/test/java/org/sonatype/nexus/ci/iq/PolicyFailureMessageFormatterTest.groovy
@@ -98,6 +98,6 @@ class PolicyFailureMessageFormatterTest
   }
 
   ApplicationPolicyEvaluation createFullModel(List<PolicyAlert> alerts) {
-    return new ApplicationPolicyEvaluation(1, 2, 3, 5, alerts, 'http://report/url')
+    return new ApplicationPolicyEvaluation(1, 2, 3, 5, 0, alerts, 'http://report/url')
   }
 }


### PR DESCRIPTION
Updates the Jenkins summary report to display grandfathered violation counts as shown below. I've explicitly avoided making any additional style changes beyond what was required to get the text to display appropriately, and I'm using the same font size that we already have for the remainder of the text in the same line (otherwise it looks kind of weird when next to the "No Violations" text).

<img width="1862" alt="screen shot 2018-08-08 at 9 36 12 pm" src="https://user-images.githubusercontent.com/3869125/43909248-ddbf20ae-9bc7-11e8-9ae5-ec11ef4ce55a.png">
<img width="1860" alt="screen shot 2018-08-08 at 9 35 29 pm" src="https://user-images.githubusercontent.com/3869125/43909253-df507800-9bc7-11e8-9e74-653db6690bbe.png">

<img width="1863" alt="screen shot 2018-08-08 at 9 35 18 pm" src="https://user-images.githubusercontent.com/3869125/43909265-e9928902-9bc7-11e8-82a0-8dc452829b46.png">
<img width="1863" alt="screen shot 2018-08-08 at 9 28 27 pm" src="https://user-images.githubusercontent.com/3869125/43909270-eb564b98-9bc7-11e8-9994-a1ceaa6eda75.png">

https://issues.sonatype.org/browse/CLM-10490
https://jenkins.zion.aws.s/job/integrations/job/jenkins/job/sonatype-nexus-platform-plugin-feature/job/CLM-10612_GrandfatheringCounts/