### PR TITLE
INT-952 Bump groovy-all to 2.4.15

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
       <dependency>
         <groupId>org.codehaus.groovy</groupId>
         <artifactId>groovy-all</artifactId>
-        <version>2.4.7</version>
+        <version>2.4.15</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Jira: https://issues.sonatype.org/browse/INT-952
CI: https://jenkins.zion.aws.s/job/integrations/job/jenkins/job/sonatype-nexus-platform-plugin-feature/job/INT-952-bump-groovy-all/