### PR TITLE
fix path to credential parameter

### DIFF
--- a/src/main/java/org/sonatype/nexus/ci/iq/SelectedApplication.java
+++ b/src/main/java/org/sonatype/nexus/ci/iq/SelectedApplication.java
@@ -15,6 +15,7 @@ package org.sonatype.nexus.ci.iq;
 import org.sonatype.nexus.ci.util.IqUtil;
 
 import hudson.Extension;
+import hudson.RelativePath;
 import hudson.model.Job;
 import hudson.util.ListBoxModel;
 import org.jenkinsci.Symbol;
@@ -44,7 +45,7 @@ public class SelectedApplication
       return Messages.IqPolicyEvaluation_SelectApplication();
     }
 
-    public ListBoxModel doFillApplicationIdItems(@QueryParameter String jobCredentialsId, @AncestorInPath Job job) {
+    public ListBoxModel doFillApplicationIdItems(@RelativePath("..") @QueryParameter String jobCredentialsId, @AncestorInPath Job job) {
       // JobCredentialsId is an empty String if not set
       return IqUtil.doFillIqApplicationItems(jobCredentialsId, job);
     }


### PR DESCRIPTION
#### Description
When implementing the `manual` application ID the path to the descriptor backing the application ID changed. Therefore the binding to the `job credential` parameter broke (always empty string). When job credentials are not available the plugin falls back to the credentials configured in the global configuration, so this was not immediately noticed.

#### Links
JIRA: https://issues.sonatype.org/browse/INT-554
Build: https://jenkins.zion.aws.s/job/integrations/job/jenkins/job/nexus-platform-plugin-feature/job/INT-554_fix_application_dropdown_credentials/1/

#### Testing
The essential part in testing it is to set up the global IQ configuration with credentials that that job does not have access to. This fix now allows you to override these (inacessible) credentials with job specific credentials and can select the application ID from the drop down list. Before that was not possible, making it impossible to select an application from the drop down list.
There is a great write-up from Jamie on the JIRA ticket.