### PR TITLE
INT-562 fix policy eval result UI/links

### DIFF
--- a/src/main/java/org/sonatype/nexus/ci/iq/PolicyEvaluationHealthAction.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/iq/PolicyEvaluationHealthAction.groovy
@@ -90,7 +90,7 @@ class PolicyEvaluationHealthAction
 
   @Override
   String getUrlName() {
-    return 'nexus-iq-application-composition-report'
+    return reportLink
   }
 
   @Override
@@ -100,7 +100,7 @@ class PolicyEvaluationHealthAction
     }
 
     def job = run.getParent()
-    return Collections.singleton(new PolicyEvaluationProjectAction(job))
+    return Collections.singleton(new PolicyEvaluationProjectAction(job, reportLink))
   }
 
   @SuppressWarnings(value = ['UnusedMethodParameter', 'SynchronizedMethod'])

--- a/src/main/java/org/sonatype/nexus/ci/iq/PolicyEvaluationProjectAction.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/iq/PolicyEvaluationProjectAction.groovy
@@ -20,12 +20,19 @@ class PolicyEvaluationProjectAction
 {
   private final Job job
 
-  PolicyEvaluationProjectAction(Job job) {
+  private final String reportLink
+
+  PolicyEvaluationProjectAction(Job job, String reportLink) {
     this.job = job
+    this.reportLink = reportLink
   }
 
   Job getJob() {
     return job
+  }
+
+  String getReportLink() {
+    return reportLink
   }
 
   @Override

--- a/src/main/resources/org/sonatype/nexus/ci/iq/PolicyEvaluationProjectAction/jobMain.groovy
+++ b/src/main/resources/org/sonatype/nexus/ci/iq/PolicyEvaluationProjectAction/jobMain.groovy
@@ -19,7 +19,11 @@ import org.sonatype.nexus.ci.iq.PolicyEvaluationProjectAction
 def t = namespace(lib.JenkinsTagLib)
 
 def projectAction = (PolicyEvaluationProjectAction) it
-def action = projectAction.getJob().lastCompletedBuild.getAction(PolicyEvaluationHealthAction.class)
+def actions = projectAction.getJob().lastCompletedBuild.getActions(PolicyEvaluationHealthAction.class)
+
+// there could be multiple policy evaluations so we need to find the specific health action that corresponds
+// to the given project action
+def action = actions ? actions.stream().find({a -> a.urlName == projectAction.reportLink}) : null
 
 if (action) {
   table(class: 'iq-job-main-table') {

--- a/src/main/resources/org/sonatype/nexus/ci/iq/PolicyEvaluationProjectAction/jobMain.groovy
+++ b/src/main/resources/org/sonatype/nexus/ci/iq/PolicyEvaluationProjectAction/jobMain.groovy
@@ -56,7 +56,7 @@ if (action) {
               margin-right: 5px;
             }
           """)
-      a(href: "lastCompletedBuild/${action.getUrlName()}", Messages.IqPolicyEvaluation_LatestReportName())
+      a(href: "${action.getUrlName()}", Messages.IqPolicyEvaluation_LatestReportName())
       br()
       img(src: "${rootURL}/plugin/nexus-jenkins-plugin/images/16x16/governance-badge.png")
       if (action.criticalComponentCount) {

--- a/src/test/java/org/sonatype/nexus/ci/iq/PolicyEvaluationHealthActionTest.groovy
+++ b/src/test/java/org/sonatype/nexus/ci/iq/PolicyEvaluationHealthActionTest.groovy
@@ -89,6 +89,7 @@ class PolicyEvaluationHealthActionTest
       def severeComponentCount = healthAction.severeComponentCount
       def moderateComponentCount = healthAction.moderateComponentCount
       def grandfatheredPolicyViolationCount = healthAction.grandfatheredPolicyViolationCount
+      def urlName = healthAction.urlName
 
     then:
       affectedComponentCount == 1
@@ -96,5 +97,21 @@ class PolicyEvaluationHealthActionTest
       severeComponentCount == 3
       moderateComponentCount == 4
       grandfatheredPolicyViolationCount == 5
+      urlName == reportLink
+  }
+
+  def 'health action and project action have matching report links'() {
+    setup:
+      def reportLink = 'http://localhost/reportLink'
+      def run = Mock(Run)
+      def policyEvaluation = new ApplicationPolicyEvaluation(1, 2, 3, 4, 5, [], reportLink)
+      def healthAction = new PolicyEvaluationHealthAction(run, policyEvaluation)
+
+    when:
+      PolicyEvaluationProjectAction projectAction = (PolicyEvaluationProjectAction)healthAction.getProjectActions()[0]
+
+    then:
+      healthAction.urlName == reportLink
+      projectAction.reportLink == reportLink
   }
 }


### PR DESCRIPTION
**Description:**
In the case of build pipelines with multiple nexusPolicyEvaluation invocations the results displayed on the job summary page had multiple entries for the same result.  In addition, on the job run page all of the report links pointed to the same report, which was for the first eval performed.  

This fix addresses both of those problems.

**Links**:
Jira: https://issues.sonatype.org/browse/INT-562
Jenkins:  ??

**Screencast**:
https://youtu.be/Aa4mU6iELS4