### PR TITLE
INT-1203 open policy eval links in new window

### DIFF
--- a/src/main/resources/org/sonatype/nexus/ci/iq/PolicyEvaluationHealthAction/summary.groovy
+++ b/src/main/resources/org/sonatype/nexus/ci/iq/PolicyEvaluationHealthAction/summary.groovy
@@ -48,7 +48,7 @@ t.summary(icon: '/plugin/nexus-jenkins-plugin/images/48x48/nexus-iq.png') {
           margin-right: 5px;
         }
       """)
-  a(href: "${action.getUrlName()}", Messages.IqPolicyEvaluation_ReportName())
+  a(href: "${action.getUrlName()}", target: "_blank", Messages.IqPolicyEvaluation_ReportName())
   br()
   img(src: "${rootURL}/plugin/nexus-jenkins-plugin/images/16x16/governance-badge.png")
   if (action.criticalComponentCount) {

--- a/src/main/resources/org/sonatype/nexus/ci/iq/PolicyEvaluationProjectAction/jobMain.groovy
+++ b/src/main/resources/org/sonatype/nexus/ci/iq/PolicyEvaluationProjectAction/jobMain.groovy
@@ -52,7 +52,7 @@ if (action) {
               margin-right: 5px;
             }
           """)
-      a(href: "lastCompletedBuild/${action.getUrlName()}", Messages.IqPolicyEvaluation_LatestReportName())
+      a(href: "lastCompletedBuild/${action.getUrlName()}", target: "_blank", Messages.IqPolicyEvaluation_LatestReportName())
       br()
       img(src: "${rootURL}/plugin/nexus-jenkins-plugin/images/16x16/governance-badge.png")
       if (action.criticalComponentCount) {


### PR DESCRIPTION
Description:
The purpose of this change was to ensure that the policy report, when accessed by clicking the link in the build results in Jenkins, will open in a new browser window rather than replacing the Jenkins window.

Links:
Jira: https://issues.sonatype.org/browse/INT-1203

Screencast:
n/a