### PR TITLE
Added support for hashing Java 10/11 bytecode - CLM-11662 CLM-11744

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
   <groupId>org.sonatype.nexus.ci</groupId>
   <artifactId>nexus-jenkins-plugin</artifactId>
-  <version>3.3-SNAPSHOT</version>
+  <version>3.4-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
   <name>Nexus Platform Plugin</name>
@@ -86,7 +86,7 @@
       <dependency>
         <groupId>com.sonatype.nexus</groupId>
         <artifactId>nexus-platform-api</artifactId>
-        <version>3.4.20181205-180005.1567c7b</version>
+        <version>3.5.20190114-150153.a6e0a60</version>
         <classifier>internal</classifier>
       </dependency>
       


### PR DESCRIPTION
Story: https://issues.sonatype.org/browse/CLM-11662
Task: https://issues.sonatype.org/browse/CLM-11744
Build: https://jenkins.zion.aws.s/job/integrations/job/jenkins/job/sonatype-nexus-platform-plugin-feature/job/CLM-11744_update_api_java_10_11/lastBuild

Although the above build works I think the continuous-integration/jenkins build won't pass until the release from https://jenkins.zion.aws.s/job/integrations/job/java-api/job/nexus-java-api/87/ becomes available

Edit: It's available on https://repo1.maven.org/maven2/com/sonatype/nexus/nexus-platform-api/3.5.20190114-150153.a6e0a60/ (thanks Justin) the CI build below is not a concern