### PR TITLE
Upgrade groovy-eclipse-batch to 2.4.16-03 for Java 11 - CLM-12408 CLM-12430

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -374,7 +374,7 @@
           <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-eclipse-batch</artifactId>
-            <version>2.4.3-01</version>
+            <version>2.4.16-03</version>
           </dependency>
         </dependencies>
       </plugin>

--- a/src/main/java/org/sonatype/nexus/ci/nxrm/MavenAsset.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/nxrm/MavenAsset.groovy
@@ -12,6 +12,8 @@
  */
 package org.sonatype.nexus.ci.nxrm
 
+import org.sonatype.nexus.ci.nxrm.Asset.AssetDescriptor
+
 import hudson.Extension
 import org.jenkinsci.Symbol
 import org.kohsuke.stapler.DataBoundConstructor
@@ -35,7 +37,7 @@ class MavenAsset
 
   @Extension
   static final class DescriptorImpl
-      extends Asset.AssetDescriptor<MavenAsset>
+      extends AssetDescriptor<MavenAsset>
   {
     @Override
     String getDisplayName() {

--- a/src/main/java/org/sonatype/nexus/ci/nxrm/MavenCoordinate.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/nxrm/MavenCoordinate.groovy
@@ -12,6 +12,8 @@
  */
 package org.sonatype.nexus.ci.nxrm
 
+import org.sonatype.nexus.ci.nxrm.Coordinate.CoordinateDescriptor
+
 import hudson.Extension
 import org.jenkinsci.Symbol
 import org.kohsuke.stapler.DataBoundConstructor
@@ -38,7 +40,7 @@ class MavenCoordinate
 
   @Extension
   static final class DescriptorImpl
-      extends Coordinate.CoordinateDescriptor<MavenCoordinate>
+      extends CoordinateDescriptor<MavenCoordinate>
   {
     @Override
     String getDisplayName() {

--- a/src/main/java/org/sonatype/nexus/ci/util/FormUtil.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/util/FormUtil.groovy
@@ -29,9 +29,9 @@ import static com.cloudbees.plugins.credentials.domains.URIRequirementBuilder.fr
 
 class FormUtil
 {
-  final static String EMPTY_LIST_BOX_NAME = '-----------'
+  public final static String EMPTY_LIST_BOX_NAME = '-----------'
 
-  final static String EMPTY_LIST_BOX_VALUE = ''
+  public final static String EMPTY_LIST_BOX_VALUE = ''
 
   static FormValidation validateUrl(String url) {
     try {


### PR DESCRIPTION
Story: https://issues.sonatype.org/browse/CLM-12408
Task: https://issues.sonatype.org/browse/CLM-12430
Build: https://jenkins.zion.aws.s/job/integrations/job/jenkins/job/sonatype-nexus-platform-plugin-feature/job/CLM-12430_openjdk_11_prep/lastBuild

Maybe counts as trivial but wasn't completely sure, maybe something I'm missing as well. This is essentially to allow us to only have to make Jenkinsfile/pom changes when configuring for Java 11