### PR TITLE
Upgrade cglib-nodep to 3.2.10 - CLM-12408 CLM-12430

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,7 +157,7 @@
       <dependency>
         <groupId>cglib</groupId>
         <artifactId>cglib-nodep</artifactId>
-        <version>3.2.4</version>
+        <version>3.2.10</version>
         <scope>test</scope>
       </dependency>
 


### PR DESCRIPTION
Story: https://issues.sonatype.org/browse/CLM-12408
Task: https://issues.sonatype.org/browse/CLM-12430
Build: https://jenkins.zion.aws.s/job/integrations/job/jenkins/job/sonatype-nexus-platform-plugin-feature/job/CLM-12430_update_cglib/lastBuild