### PR TITLE
 Added jaxb dependencies for Java 11 compatibility - CLM-12408 CLM-12430

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -286,6 +286,23 @@
       <artifactId>wiremock-standalone</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <!-- For Java 11-->
+    <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+      <version>2.3.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-core</artifactId>
+      <version>2.3.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-impl</artifactId>
+      <version>2.3.0</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
   <properties>
     <enforcer.skip>true</enforcer.skip> <!-- TODO numerous requireUpperBoundDeps, some probably indicative of real problems -->
     <jenkins.version>2.7</jenkins.version>
-    <findbugs-maven-plugin.version>3.0.2</findbugs-maven-plugin.version>
+    <findbugs-maven-plugin.version>3.0.5</findbugs-maven-plugin.version>
     <jvnet-localizer-plugin.version>1.23</jvnet-localizer-plugin.version>
     <forkCount>1</forkCount>
     <java.level>8</java.level>
@@ -314,6 +314,11 @@
     </resources>
     <pluginManagement>
       <plugins>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>animal-sniffer-maven-plugin</artifactId>
+          <version>1.17</version>
+        </plugin>
         <plugin>
           <groupId>org.kohsuke</groupId>
           <artifactId>access-modifier-checker</artifactId>


### PR DESCRIPTION
Story: https://issues.sonatype.org/browse/CLM-12408
Task: https://issues.sonatype.org/browse/CLM-12430
Build: https://jenkins.zion.aws.s/job/integrations/job/jenkins/job/sonatype-nexus-platform-plugin-feature/job/CLM-12430_jaxb/lastBuild

To be built and merged after https://github.com/jenkinsci/nexus-platform-plugin/pull/71