### PR TITLE
Disable unused javadoc maven plugin - CLM-12408 CLM-12430

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -298,6 +298,12 @@
     <pluginManagement>
       <plugins>
         <plugin>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <configuration>
+            <skip>true</skip>
+          </configuration>
+        </plugin>
+        <plugin>
           <groupId>org.kohsuke</groupId>
           <artifactId>access-modifier-checker</artifactId>
           <version>1.7</version>


### PR DESCRIPTION
Story: https://issues.sonatype.org/browse/CLM-12408
Task: https://issues.sonatype.org/browse/CLM-12430
Build: https://jenkins.zion.aws.s/job/integrations/job/jenkins/job/sonatype-nexus-platform-plugin-feature/job/CLM-12430_disable_javadoc/lastBuild