### PR TITLE
INT-1955 - Fail with error message if not in agent/node context

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
   <groupId>org.sonatype.nexus.ci</groupId>
   <artifactId>nexus-jenkins-plugin</artifactId>
-  <version>3.7-SNAPSHOT</version>
+  <version>3.8-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
   <name>Nexus Platform Plugin</name>

--- a/src/main/resources/org/sonatype/nexus/ci/iq/Messages.properties
+++ b/src/main/resources/org/sonatype/nexus/ci/iq/Messages.properties
@@ -34,6 +34,7 @@ IqPolicyEvaluation.NoIqServersConfigured=No IQ Server configured.
 
 IqPolicyEvaluation.EvaluationFailed=IQ Server evaluation of application {0} failed
 IqPolicyEvaluation.EvaluationWarning=IQ Server evaluation of application {0} detected warnings
+IqPolicyEvaluation.NodeContextRequired=nexusPolicyEvaluation step requires a node context. Please specify an agent or a node block
 
 IqPolicyEvaluation.ReportName=Nexus IQ Policy Evaluation
 IqPolicyEvaluation.LatestReportName=Latest Nexus IQ Policy Evaluation


### PR DESCRIPTION
#### Description
Problem: 
Nexus policy evaluation step fails with NPE if not in an agent/node context (see Jira like for details).
Fix: 
Nexus policy evaluation step check upfront if it runs in an agent/node context. If not it fails the build with an appropriate error message.

#### Links
JIRA: https://issues.sonatype.org/browse/INT-1955
Build: https://jenkins.zion.aws.s/job/integrations/job/jenkins/job/sonatype-nexus-platform-plugin-feature/job/INT-1955-plugin-requires-agent/1/