### PR TITLE
INT-2083 Commit hash cannot be determined

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,6 @@
         <artifactId>servlet-api</artifactId>
         <version>2.4</version>
       </dependency>
-
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>credentials</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,7 @@
         <artifactId>servlet-api</artifactId>
         <version>2.4</version>
       </dependency>
+
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>credentials</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
       <dependency>
         <groupId>com.sonatype.nexus</groupId>
         <artifactId>nexus-platform-api</artifactId>
-        <version>3.9-SNAPSHOT</version>
+        <version>3.10-SNAPSHOT</version>
         <classifier>internal</classifier>
       </dependency>
       

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
       <dependency>
         <groupId>com.sonatype.nexus</groupId>
         <artifactId>nexus-platform-api</artifactId>
-        <version>3.10-SNAPSHOT</version>
+        <version>3.10.20190916-091644.60b49d8</version>
         <classifier>internal</classifier>
       </dependency>
       

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
   <groupId>org.sonatype.nexus.ci</groupId>
   <artifactId>nexus-jenkins-plugin</artifactId>
-  <version>3.7-SNAPSHOT</version>
+  <version>3.8-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
   <name>Nexus Platform Plugin</name>
@@ -88,7 +88,7 @@
       <dependency>
         <groupId>com.sonatype.nexus</groupId>
         <artifactId>nexus-platform-api</artifactId>
-        <version>3.8.20190821-172053.8894a6d</version>
+        <version>3.9-SNAPSHOT</version>
         <classifier>internal</classifier>
       </dependency>
       

--- a/src/main/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorUtil.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorUtil.groovy
@@ -69,7 +69,8 @@ class IqPolicyEvaluatorUtil
               advancedProperties)
       def scanResult = launcher.getChannel().call(remoteScanner).copyToLocalScanResult()
 
-      def evaluationResult = iqClient.evaluateApplication(applicationId, iqStage, scanResult)
+      File workDirectory = new File(workspace.getRemote())
+      def evaluationResult = iqClient.evaluateApplication(applicationId, iqStage, scanResult, workDirectory)
 
       def healthAction = new PolicyEvaluationHealthAction(applicationId, iqStage, run, evaluationResult)
       run.addAction(healthAction)

--- a/src/test/java/org/sonatype/nexus/ci/config/ComToOrgMigratorIntegrationTest.groovy
+++ b/src/test/java/org/sonatype/nexus/ci/config/ComToOrgMigratorIntegrationTest.groovy
@@ -97,7 +97,7 @@ class ComToOrgMigratorIntegrationTest
     then: 'the application is scanned and evaluated'
       1 * iqClient.verifyOrCreateApplication(*_) >> true
       1 * iqClient.scan(*_) >> new ScanResult(new Scan(), File.createTempFile('dummy-scan', '.xml.gz'))
-      1 * iqClient.evaluateApplication('sample-app', 'build', _) >> new ApplicationPolicyEvaluation(0, 1, 2, 3, 0, [],
+      1 * iqClient.evaluateApplication('sample-app', 'build', _, _) >> new ApplicationPolicyEvaluation(0, 1, 2, 3, 0, [],
           'http://server/link/to/report')
 
     then: 'the return code is successful'
@@ -120,7 +120,7 @@ class ComToOrgMigratorIntegrationTest
     then: 'the application is scanned and evaluated'
       1 * iqClient.verifyOrCreateApplication(*_) >> true
       1 * iqClient.scan(*_) >> new ScanResult(new Scan(), File.createTempFile('dummy-scan', '.xml.gz'))
-      1 * iqClient.evaluateApplication('sample-app', 'build', _) >> new ApplicationPolicyEvaluation(0, 1, 2, 3, 0, [],
+      1 * iqClient.evaluateApplication('sample-app', 'build', _, _) >> new ApplicationPolicyEvaluation(0, 1, 2, 3, 0, [],
           'http://server/link/to/report')
 
     then: 'the expected result is returned'

--- a/src/test/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorIntegrationTest.groovy
+++ b/src/test/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorIntegrationTest.groovy
@@ -600,7 +600,7 @@ class IqPolicyEvaluatorIntegrationTest
     then: 'the application is scanned and evaluated'
       1 * iqClient.verifyOrCreateApplication('app') >> true
       1 * iqClient.scan(*_) >> new ScanResult(new Scan(), File.createTempFile('dummy-scan', '.xml.gz'))
-      1 * iqClient.evaluateApplication('app', _, _) >> new ApplicationPolicyEvaluation(0, 1, 2, 3, 0, [],
+      1 * iqClient.evaluateApplication('app', _, _, _) >> new ApplicationPolicyEvaluation(0, 1, 2, 3, 0, [],
           'http://server/link/to/report')
 
     then: 'the return code is successful'
@@ -625,7 +625,7 @@ class IqPolicyEvaluatorIntegrationTest
     then: 'the application is scanned and evaluated'
       1 * iqClient.verifyOrCreateApplication('app') >> true
       1 * iqClient.scan(*_) >> new ScanResult(new Scan(), File.createTempFile('dummy-scan', '.xml.gz'))
-      1 * iqClient.evaluateApplication('app', _, _) >> new ApplicationPolicyEvaluation(0, 1, 2, 3, 0, [],
+      1 * iqClient.evaluateApplication('app', _, _, _) >> new ApplicationPolicyEvaluation(0, 1, 2, 3, 0, [],
           'http://server/link/to/report')
 
     then: 'the return code is successful'

--- a/src/test/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorSlaveIntegrationTest.groovy
+++ b/src/test/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorSlaveIntegrationTest.groovy
@@ -93,6 +93,13 @@ class IqPolicyEvaluatorSlaveIntegrationTest
         "name": "sonatype-clm-server",
         "timestamp": "201807111516",
         "build": "build-number"}""")))
+    givenThat(post(urlMatching('/api/v2/sourceControl.*'))
+        .willReturn(okJson("""{"id": "id",
+            "ownerId" : "",
+            "repositoryUrl": "",
+            "token": "",
+            "provider": ""
+            }""")))
   }
 
   def configureJenkins() {

--- a/src/test/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorTest.groovy
+++ b/src/test/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorTest.groovy
@@ -76,7 +76,7 @@ class IqPolicyEvaluatorTest
     NxiqConfiguration.serverUrl >> URI.create("http://server/path")
     NxiqConfiguration.credentialsId >> '123-cred-456'
     GlobalNexusConfiguration.instanceId >> 'instance-id'
-    iqClient.evaluateApplication("appId", "stage", _) >> new ApplicationPolicyEvaluation(0, 0, 0, 0, 0, [],
+    iqClient.evaluateApplication("appId", "stage", _, _) >> new ApplicationPolicyEvaluation(0, 0, 0, 0, 0, [],
         reportUrl)
     IqClientFactory.getIqClient(*_) >> iqClient
     remoteScanResult.copyToLocalScanResult() >> scanResult
@@ -104,7 +104,7 @@ class IqPolicyEvaluatorTest
       1 * channel.call(remoteScanner) >> remoteScanResult
 
     then: 'evaluates the result'
-      1 * iqClient.evaluateApplication("appId", "stage", scanResult) >> evaluationResult
+      1 * iqClient.evaluateApplication("appId", "stage", scanResult, _) >> evaluationResult
   }
 
   def 'it expands environment variables for scan pattern'() {
@@ -251,7 +251,7 @@ class IqPolicyEvaluatorTest
 
     then:
       1 * iqClient.verifyOrCreateApplication(*_) >> true
-      1 * iqClient.evaluateApplication('appId', 'stage', scanResult) >>
+      1 * iqClient.evaluateApplication('appId', 'stage', scanResult, _) >>
           { throw new IqClientException('SNAP', new IOException('CRASH')) }
       noExceptionThrown()
   }
@@ -282,7 +282,7 @@ class IqPolicyEvaluatorTest
 
     then:
       1 * iqClient.verifyOrCreateApplication(*_) >> true
-      1 * iqClient.evaluateApplication('appId', 'stage', scanResult) >>
+      1 * iqClient.evaluateApplication('appId', 'stage', scanResult, _) >>
           new ApplicationPolicyEvaluation(0, 0, 0, 0, 0, alerts, reportUrl)
       1 * run.setResult(buildResult)
 
@@ -305,7 +305,7 @@ class IqPolicyEvaluatorTest
 
     then:
       1 * iqClient.verifyOrCreateApplication(*_) >> true
-      1 * iqClient.evaluateApplication('appId', 'stage', scanResult) >> policyEvaluation
+      1 * iqClient.evaluateApplication('appId', 'stage', scanResult, _) >> policyEvaluation
       1 * run.setResult(Result.FAILURE)
 
     and:
@@ -328,7 +328,7 @@ class IqPolicyEvaluatorTest
 
     then:
       1 * iqClient.verifyOrCreateApplication(*_) >> true
-      1 * iqClient.evaluateApplication('appId', 'stage', scanResult) >>
+      1 * iqClient.evaluateApplication('appId', 'stage', scanResult, _) >>
           new ApplicationPolicyEvaluation(0, 1, 2, 3, 0, [new PolicyAlert(trigger, [new Action(Action.ID_FAIL)])],
               reportUrl)
 
@@ -355,7 +355,7 @@ class IqPolicyEvaluatorTest
 
     then:
       1 * iqClient.verifyOrCreateApplication(*_) >> true
-      1 * iqClient.evaluateApplication('appId', 'stage', scanResult) >>
+      1 * iqClient.evaluateApplication('appId', 'stage', scanResult, _) >>
           new ApplicationPolicyEvaluation(0, 1, 2, 3, 0, [new PolicyAlert(trigger, [new Action(Action.ID_WARN)])],
               reportUrl)
       1 * log.println("IQ Server evaluation of application appId detected warnings")
@@ -378,7 +378,7 @@ class IqPolicyEvaluatorTest
 
     then:
       1 * iqClient.verifyOrCreateApplication(*_) >> true
-      1 * iqClient.evaluateApplication('appId', 'stage', scanResult) >>
+      1 * iqClient.evaluateApplication('appId', 'stage', scanResult, _) >>
           new ApplicationPolicyEvaluation(0, 0, 0, 0, 0, [],
               reportUrl)
       0 * log.println("WARNING: IQ Server evaluation of application appId detected warnings.")


### PR DESCRIPTION
#### Description
It was reported that a user running Nexus Platform Plugin 3.7.20190823-091836.9f85050 on a standalone Jenkins installation does not get commit status updates after the policy evaluation step is executed.

During investigation it was found that the commit hash is not determined, so no attempt to update the commit status is made.

**Solution**:
Make sure that JGitCommitHashFinder uses Jenkins' workspace directory as a starting point for the git directory lookup, instead of the current working directory (as it is now)

#### Links
JIRA: https://issues.sonatype.org/browse/INT-2083
Build: https://jenkins.zion.aws.s/job/integrations/job/jenkins/job/sonatype-nexus-platform-plugin-feature/job/INT-2083-commit-hash-cannot-be-determined/5/