### PR TITLE
Enable third party scanning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
       <dependency>
         <groupId>com.sonatype.nexus</groupId>
         <artifactId>nexus-platform-api</artifactId>
-        <version>3.10.20191024-134537.5af10c2</version>
+        <version>3.10.20191126-161807.6e95e4b</version>
         <classifier>internal</classifier>
       </dependency>
 


### PR DESCRIPTION
Jira: https://issues.sonatype.org/browse/CLM-14057

Bump up nexus-platform-api to 3.10.20191126-161807.6e95e4b which has third party scanning enabled (Clair and CycloneDX SBOM) from `insight-scanner`