### PR TITLE
INTC-132 Update missing changelog entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ Please use the links below to find information about using the plugin with your 
 Changelog
 =========
 
-3.8.20191127-111424.5d61f82 (November 11th, 2019)
+3.8.20191127-111424.5d61f82 (November 27th, 2019)
 --------------------------------------------------
-
+- Add trend graph to a Pipeline, which depicts the information about the last 5 builds with critical, severe and moderate violation numbers
 - [Support to scan and evaluate Clair identified container dependencies](https://help.sonatype.com/iqserver/analysis/clair-application-analysis)
 - [Support to scan and evaluate identified dependencies from a CycloneDX SBOM file](https://help.sonatype.com/iqserver/analysis/cyclonedx-application-analysis)
 

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   <packaging>hpi</packaging>
 
   <name>Nexus Platform Plugin</name>
-  <url>https://wiki.jenkins-ci.org/display/JENKINS/Nexus+Platform+Plugin</url>
+  <url>https://github.com/jenkinsci/nexus-platform-plugin</url>
 
   <licenses>
     <license>


### PR DESCRIPTION
#### Description
Use [GitHub README](https://jenkins.io/blog/2019/10/21/plugin-docs-on-github/) instead of [Jenkins Wiki](https://wiki.jenkins.io/display/JENKINS/Nexus+Platform+Plugin)

#### Links
JIRA: [INTC-132](https://issues.sonatype.org/browse/INTC-132)
Build: 
* [Downstream Jenkins Job](https://jenkins.ci.sonatype.dev/job/integrations/job/jenkins/job/sonatype-nexus-platform-plugin-feature/job/intc-132-update-jenkins-to-use-github-readme-for-plugins-page/)
* [Upstream Jenkins Job](https://ci.jenkins.io/blue/organizations/jenkins/Plugins%2Fnexus-platform-plugin/detail/PR-106/1/pipeline)

#### Screencast
N/A