### PR TITLE
INTC-95 Jenkins Plugin Build Report style fixes

### DIFF
--- a/src/main/java/org/sonatype/nexus/ci/iq/PolicyEvaluationReportAction.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/iq/PolicyEvaluationReportAction.groovy
@@ -26,7 +26,7 @@ class PolicyEvaluationReportAction
 
   private static final String IQ_REPORT_NAME = 'iqreport'
 
-  private static final String MENU_REPORT_TITLE = 'Nexus IQ Build Failure Report'
+  private static final String MENU_REPORT_TITLE = 'Nexus IQ Build Report'
 
   private static final String IQ_SPACE_SHIP_PNG = '/plugin/nexus-jenkins-plugin/images/sonatype-iq-rocketship.png'
   private static final String IQ_SPACE_SHIP_SUCCESS_MESSAGE = 'We\'re all clear!'

--- a/src/main/resources/org/sonatype/nexus/ci/iq/PolicyEvaluationReportAction/index.jelly
+++ b/src/main/resources/org/sonatype/nexus/ci/iq/PolicyEvaluationReportAction/index.jelly
@@ -37,7 +37,7 @@
       }
 
       .report-parent div.title {
-        display: flex;
+        display: block;
         flex-direction: row;
         flex-wrap: nowrap;
         justify-content: flex-start;
@@ -53,11 +53,16 @@
         font-size: 18px;
       }
 
-      .report-parent div.title div.report {
+      .report-parent div.title{
         font-weight: bold;
         font-size: 12px;
         padding-top: 5px;
-        margin-left: 15px;
+      }
+
+      div.report {
+        font-weight: normal;
+        font-size: 12px;
+        padding-top: 5px;
       }
 
       .report-parent div.general-info {
@@ -343,9 +348,10 @@
       <j:set var="report" value="${it.getReport()}" />
       <div id="nexusIqParent" class="report-parent">
         <div class="title">
-          <div class="main-title">Nexus IQ Build Failure Report</div>
+          <div class="main-title">Nexus IQ Build Report</div>
           <div class="report">
-            <a href="${it.url}">View IQ Server Application Report</a>
+            This report lists IQ policy violations which are configured to 'warn' or 'fail.
+            <a href="${it.url}">See full report in IQ Server</a>
           </div>
         </div>
 


### PR DESCRIPTION
#### Description
Jenkins Plugin Build Report - small style fixes
The Build Failure Report should be accessible from the build page in Jenkins, under a job. It should show up in the left hand navigation under Nexus IQ Policy Evaluation.

#### Links
JIRA: https://issues.sonatype.org/browse/INTC-95
Build: https://ci.jenkins.io/blue/organizations/jenkins/Plugins%2Fnexus-platform-plugin/detail/PR-107/1/

#### Screencast
https://youtu.be/DSoR_7dYRTA