### PR TITLE
INTC-136 Jenkins build chart shows float yaxis values

### DIFF
--- a/src/main/webapp/features/iq/charting/iqChart.js
+++ b/src/main/webapp/features/iq/charting/iqChart.js
@@ -58,6 +58,10 @@ function getXAxisLabels() {
   return policyEvaluations ? policyEvaluations.map(value => value.buildNumber) : [];
 }
 
+function getMaxValue() {
+  return getCriticalValues().concat(getSevereValues()).concat(getModerateValues()).max();
+}
+
 const options = {
   chart: {
     height: CHART_HEIGHT,
@@ -118,6 +122,9 @@ const options = {
     }
   },
   yaxis: {
+    min: 0,
+    max: getMaxValue() + 1,
+    forceNiceScale: true,
     labels: {
       formatter: function (value) {
         return value;


### PR DESCRIPTION
#### Description
In the Jenkins -> Pipeline for "Trends for Nexus IQ Policy Evaluation" on the y-axis shows float values instead of integer ones.

#### Links
JIRA: [INTC-136](https://issues.sonatype.org/browse/INTC-136)
Build: 
* [Downstream Jenkins Job](https://jenkins.ci.sonatype.dev/job/integrations/job/jenkins/job/sonatype-nexus-platform-plugin-feature/job/intc-136-jenkins-build-chart-shows-float-yaxis-values/)

#### Screencast
See screens from the [ticket](https://issues.sonatype.org/browse/INTC-136?focusedCommentId=888109&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-888109)