### PR TITLE
Whitelist additional classes for xtream

### DIFF
--- a/src/main/resources/META-INF/hudson.remoting.ClassFilter
+++ b/src/main/resources/META-INF/hudson.remoting.ClassFilter
@@ -7,3 +7,8 @@ com.sonatype.insight.scan.model.ScanConfiguration
 com.sonatype.insight.scan.model.ScanItem
 com.sonatype.insight.scan.model.ScanSummary
 com.sonatype.nexus.api.iq.ApplicationPolicyEvaluation
+com.sonatype.nexus.api.iq.PolicyAlert
+com.sonatype.nexus.api.iq.PolicyFact
+com.sonatype.nexus.api.iq.ComponentFact
+com.sonatype.nexus.api.iq.ConstraintFact
+com.sonatype.nexus.api.iq.ConditionFact

--- a/src/main/resources/META-INF/hudson.remoting.ClassFilter
+++ b/src/main/resources/META-INF/hudson.remoting.ClassFilter
@@ -6,3 +6,4 @@ com.sonatype.insight.scan.model.Scan
 com.sonatype.insight.scan.model.ScanConfiguration
 com.sonatype.insight.scan.model.ScanItem
 com.sonatype.insight.scan.model.ScanSummary
+com.sonatype.nexus.api.iq.ApplicationPolicyEvaluation


### PR DESCRIPTION
The recent build trend graph (#99) is causing issues in relation to JEP-200 (whitelisting instead of blacklisting for serialized data). Needed to add these additional classes to the class filter.

Downstream ticket: https://issues.sonatype.org/browse/INT-2407
Downstream CI: https://jenkins.ci.sonatype.dev/job/integrations/job/jenkins/job/sonatype-nexus-platform-plugin-feature/job/INT-2407-marshal-error/