### PR TITLE
Update nexus-java-api and pass down the build logger - INT-2484

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,6 @@
     <findbugs.effort>Max</findbugs.effort>
   </properties>
 
-
   <dependencyManagement>
     <dependencies>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
       <dependency>
         <groupId>com.sonatype.nexus</groupId>
         <artifactId>nexus-platform-api</artifactId>
-        <version>3.13-SNAPSHOT</version>
+        <version>3.13</version>
         <classifier>internal</classifier>
       </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
       <dependency>
         <groupId>com.sonatype.nexus</groupId>
         <artifactId>nexus-platform-api</artifactId>
-        <version>3.11.20191129-110145.6dda2ea</version>
+        <version>3.13-SNAPSHOT</version>
         <classifier>internal</classifier>
       </dependency>
 

--- a/src/main/java/org/sonatype/nexus/ci/iq/RemoteRepositoryUrlFinder.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/iq/RemoteRepositoryUrlFinder.groovy
@@ -53,6 +53,7 @@ class RemoteRepositoryUrlFinder
           .withEnvironmentVariableDefault()
           .withGitRepoAtPath(workDirectory == null ? null : workDirectory.getAbsolutePath() + '/.git')
           .withEnvironmentOverride(envVars)
+          .withLogger(log)
           .build()
           .tryGetRepositoryUrl()
       if (optional.isPresent()) {


### PR DESCRIPTION
#### Description
The commit hash and the repository URL finders use class-instantiated loggers to log relevant information. 

In Jenkins it is desirable that the discovery information ends up in the build log, rather than the system log. 

The purpose of this change is to pass down to those finders the build logger

#### Links
JIRA: https://issues.sonatype.org/browse/INT-2484
