### PR TITLE
Enable Conan, Composer and Gemfile manifest scanning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
       <dependency>
         <groupId>com.sonatype.nexus</groupId>
         <artifactId>nexus-platform-api</artifactId>
-        <version>3.13</version>
+        <version>3.14</version>
         <classifier>internal</classifier>
       </dependency>
 


### PR DESCRIPTION
Jira: https://issues.sonatype.org/browse/CLM-15068
Jenkins: https://jenkins.ci.sonatype.dev/job/integrations/job/jenkins/job/nexus-platform-plugin-feature/job/enable_third_party_scans_default/

As a part of CLM-15068, we want to update the version of `nexus-platform-api` to the version enabling  scanning conanfile.txt (C++) / Gemfile.lock (RubyGems) / composer.lock (PHP) files by default.

Below are screen shot's of the jenkins plugin built from this branch, scanning the above mentioned scan files (enabled by default).

PHP  (composer)
![image](https://user-images.githubusercontent.com/38332365/76305320-db400100-62bc-11ea-9f37-47d3c80443b5.png)

Ruby (gemfile)
![image](https://user-images.githubusercontent.com/38332365/76305303-d418f300-62bc-11ea-80e9-678e87e2ebdb.png)

C++ (conan)
![image](https://user-images.githubusercontent.com/38332365/76305333-e2670f00-62bc-11ea-9a53-2cda41811987.png)
