### PR TITLE
Show summary from the policy centric report - INT-2832

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
       <dependency>
         <groupId>com.sonatype.nexus</groupId>
         <artifactId>nexus-platform-api</artifactId>
-        <version>3.15-SNAPSHOT</version>
+        <version>3.15</version>
         <classifier>internal</classifier>
       </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
       <dependency>
         <groupId>com.sonatype.nexus</groupId>
         <artifactId>nexus-platform-api</artifactId>
-        <version>3.14</version>
+        <version>3.15-SNAPSHOT</version>
         <classifier>internal</classifier>
       </dependency>
 

--- a/src/main/java/org/sonatype/nexus/ci/iq/PolicyEvaluationHealthAction.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/iq/PolicyEvaluationHealthAction.groovy
@@ -33,11 +33,11 @@ class PolicyEvaluationHealthAction
 
   private final int affectedComponentCount
 
-  private final int criticalComponentCount
+  private final int criticalPolicyViolationCount
 
-  private final int severeComponentCount
+  private final int severePolicyViolationCount
 
-  private final int moderateComponentCount
+  private final int moderatePolicyViolationCount
   
   private final int grandfatheredPolicyViolationCount
 
@@ -53,9 +53,9 @@ class PolicyEvaluationHealthAction
     this.run = run
     this.reportLink = policyEvaluationResult.applicationCompositionReportUrl
     this.affectedComponentCount = policyEvaluationResult.affectedComponentCount
-    this.criticalComponentCount = policyEvaluationResult.criticalComponentCount
-    this.severeComponentCount = policyEvaluationResult.severeComponentCount
-    this.moderateComponentCount = policyEvaluationResult.moderateComponentCount
+    this.criticalPolicyViolationCount = policyEvaluationResult.criticalPolicyViolationCount
+    this.severePolicyViolationCount = policyEvaluationResult.severePolicyViolationCount
+    this.moderatePolicyViolationCount = policyEvaluationResult.moderatePolicyViolationCount
     this.grandfatheredPolicyViolationCount = policyEvaluationResult.grandfatheredPolicyViolationCount
   }
 
@@ -63,16 +63,16 @@ class PolicyEvaluationHealthAction
     return run.number
   }
 
-  int getCriticalComponentCount() {
-    return criticalComponentCount
+  int getCriticalPolicyViolationCount() {
+    return criticalPolicyViolationCount
   }
 
-  int getSevereComponentCount() {
-    return severeComponentCount
+  int getSeverePolicyViolationCount() {
+    return severePolicyViolationCount
   }
 
-  int getModerateComponentCount() {
-    return moderateComponentCount
+  int getModeratePolicyViolationCount() {
+    return moderatePolicyViolationCount
   }
 
   int getGrandfatheredPolicyViolationCount() {

--- a/src/main/java/org/sonatype/nexus/ci/iq/PolicyFailureMessageFormatter.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/iq/PolicyFailureMessageFormatter.groovy
@@ -41,8 +41,8 @@ class PolicyFailureMessageFormatter
     def warnings = groupedActions.get(Action.ID_WARN).
         collect { Messages.PolicyFailureMessageFormatter_PolicyWarning(it) }
     def summary = [Messages.PolicyFailureMessageFormatter_EvaluationReport(evaluation.applicationCompositionReportUrl),
-                   Messages.PolicyFailureMessageFormatter_EvaluationSummary(evaluation.criticalComponentCount,
-                       evaluation.severeComponentCount, evaluation.moderateComponentCount)]
+                   Messages.PolicyFailureMessageFormatter_EvaluationSummary(evaluation.criticalPolicyViolationCount,
+                       evaluation.severePolicyViolationCount, evaluation.moderatePolicyViolationCount)]
     return ([(failures + warnings).join('\n\n')] + summary).join('\n')
   }
 

--- a/src/main/resources/org/sonatype/nexus/ci/iq/PolicyEvaluationHealthAction/summary.groovy
+++ b/src/main/resources/org/sonatype/nexus/ci/iq/PolicyEvaluationHealthAction/summary.groovy
@@ -93,9 +93,9 @@ def policyUI = {
       }
     }
     div(class: 'p-iq-chiclet') {
-      span(class: 'iq-chiclet critical', action.criticalComponentCount ? action.criticalComponentCount : 0)
-      span(class: 'iq-chiclet severe', action.severeComponentCount ? action.severeComponentCount : 0)
-      span(class: 'iq-chiclet moderate', action.moderateComponentCount ? action.moderateComponentCount : 0)
+      span(class: 'iq-chiclet critical', action.criticalPolicyViolationCount ? action.criticalPolicyViolationCount : 0)
+      span(class: 'iq-chiclet severe', action.severePolicyViolationCount ? action.severePolicyViolationCount : 0)
+      span(class: 'iq-chiclet moderate', action.moderatePolicyViolationCount ? action.moderatePolicyViolationCount : 0)
       span(class: 'iq-chiclet-message',
           Messages.IqPolicyEvaluation_NumberGrandfathered(action.grandfatheredPolicyViolationCount))
     }

--- a/src/main/resources/org/sonatype/nexus/ci/iq/PolicyEvaluationProjectAction/jobMain.groovy
+++ b/src/main/resources/org/sonatype/nexus/ci/iq/PolicyEvaluationProjectAction/jobMain.groovy
@@ -122,9 +122,9 @@ if (action) {
         }
       }
       div(class: 'p-iq-chiclet') {
-        span(class: 'iq-chiclet critical', action.criticalComponentCount ? action.criticalComponentCount : 0)
-        span(class: 'iq-chiclet severe', action.severeComponentCount ? action.severeComponentCount : 0)
-        span(class: 'iq-chiclet moderate', action.moderateComponentCount ? action.moderateComponentCount : 0)
+        span(class: 'iq-chiclet critical', action.criticalPolicyViolationCount ? action.criticalPolicyViolationCount : 0)
+        span(class: 'iq-chiclet severe', action.severePolicyViolationCount ? action.severePolicyViolationCount : 0)
+        span(class: 'iq-chiclet moderate', action.moderatePolicyViolationCount ? action.moderatePolicyViolationCount : 0)
         span(class: 'iq-chiclet-message',
             Messages.IqPolicyEvaluation_NumberGrandfathered(action.grandfatheredPolicyViolationCount))
       }

--- a/src/main/resources/org/sonatype/nexus/ci/iq/PolicyEvaluationProjectAction/jobMain.groovy
+++ b/src/main/resources/org/sonatype/nexus/ci/iq/PolicyEvaluationProjectAction/jobMain.groovy
@@ -162,8 +162,8 @@ class Summary {
 
   Summary(PolicyEvaluationHealthAction action) {
     this.buildNumber = action.getBuildNumber()
-    this.criticalCount = action.getCriticalComponentCount()
-    this.severeCount = action.getSevereComponentCount()
-    this.moderateCount = action.getModerateComponentCount()
+    this.criticalCount = action.getCriticalPolicyViolationCount()
+    this.severeCount = action.getSeverePolicyViolationCount()
+    this.moderateCount = action.getModeratePolicyViolationCount()
   }
 }

--- a/src/test/java/org/sonatype/nexus/ci/config/ComToOrgMigratorIntegrationTest.groovy
+++ b/src/test/java/org/sonatype/nexus/ci/config/ComToOrgMigratorIntegrationTest.groovy
@@ -99,7 +99,7 @@ class ComToOrgMigratorIntegrationTest
     then: 'the application is scanned and evaluated'
       1 * iqClient.verifyOrCreateApplication(*_) >> true
       1 * iqClient.scan(*_) >> new ScanResult(new Scan(), File.createTempFile('dummy-scan', '.xml.gz'))
-      1 * iqClient.evaluateApplication('sample-app', 'build', _, _) >> new ApplicationPolicyEvaluation(0, 1, 2, 3, 0, [],
+      1 * iqClient.evaluateApplication('sample-app', 'build', _, _) >> new ApplicationPolicyEvaluation(0, 1, 2, 3, 11, 12, 13, 0, [],
           'http://server/link/to/report')
 
     then: 'the return code is successful'
@@ -122,7 +122,7 @@ class ComToOrgMigratorIntegrationTest
     then: 'the application is scanned and evaluated'
       1 * iqClient.verifyOrCreateApplication(*_) >> true
       1 * iqClient.scan(*_) >> new ScanResult(new Scan(), File.createTempFile('dummy-scan', '.xml.gz'))
-      1 * iqClient.evaluateApplication('sample-app', 'build', _, _) >> new ApplicationPolicyEvaluation(0, 1, 2, 3, 0, [],
+      1 * iqClient.evaluateApplication('sample-app', 'build', _, _) >> new ApplicationPolicyEvaluation(0, 1, 2, 3, 11, 12, 13,  0, [],
           'http://server/link/to/report')
 
     then: 'the expected result is returned'

--- a/src/test/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorIntegrationTest.groovy
+++ b/src/test/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorIntegrationTest.groovy
@@ -101,7 +101,7 @@ class IqPolicyEvaluatorIntegrationTest
       1 * iqClient.verifyOrCreateApplication(*_) >> true
       1 * iqClient.scan(*_) >> new ScanResult(new Scan(), File.createTempFile('dummy-scan', '.xml.gz'))
       1 * iqClient.evaluateApplication(*_) >>
-          new ApplicationPolicyEvaluation(0, 1, 2, 3, 0, [createAlert(Action.ID_NOTIFY)],
+          new ApplicationPolicyEvaluation(0, 1, 2, 3, 11, 12, 13, 0, [createAlert(Action.ID_NOTIFY)],
               'http://server/link/to/report')
 
     and: 'the build is successful'
@@ -138,7 +138,7 @@ class IqPolicyEvaluatorIntegrationTest
           }, _, _, _, _) >>
             new ScanResult(new Scan(), File.createTempFile('dummy-scan', '.xml.gz'))
       1 * iqClient.evaluateApplication(*_) >>
-          new ApplicationPolicyEvaluation(0, 1, 2, 3, 0, [], 'http://server/link/to/report')
+          new ApplicationPolicyEvaluation(0, 1, 2, 3, 11, 12, 13, 0, [], 'http://server/link/to/report')
 
     and: 'the build is successful'
       jenkins.assertBuildStatusSuccess(build)
@@ -171,7 +171,7 @@ class IqPolicyEvaluatorIntegrationTest
       1 * iqClient.verifyOrCreateApplication('app') >> true
       1 * iqClient.scan(*_) >> new ScanResult(new Scan(), File.createTempFile('dummy-scan', '.xml.gz'))
       1 * iqClient.evaluateApplication(*_) >>
-          new ApplicationPolicyEvaluation(0, 1, 2, 3, 0, [], 'http://server/link/to/report')
+          new ApplicationPolicyEvaluation(0, 1, 2, 3, 11, 12, 13, 0, [], 'http://server/link/to/report')
 
     and: 'the build is successful'
       jenkins.assertBuildStatusSuccess(build)
@@ -189,9 +189,9 @@ class IqPolicyEvaluatorIntegrationTest
           'iqStage: \'stage\'\n' +
           'echo "url:" + result.applicationCompositionReportUrl\n' +
           'echo "affected:" + result.affectedComponentCount\n' +
-          'echo "critical:" + result.criticalComponentCount\n' +
-          'echo "severe:" + result.severeComponentCount\n' +
-          'echo "moderate:" + result.moderateComponentCount\n' +
+          'echo "critical:" + result.criticalPolicyViolationCount\n' +
+          'echo "severe:" + result.severePolicyViolationCount\n' +
+          'echo "moderate:" + result.moderatePolicyViolationCount\n' +
           'echo "url:" + result.applicationCompositionReportUrl\n' +
           'echo "alerts:" + result.policyAlerts' +
           '}\n')
@@ -200,7 +200,7 @@ class IqPolicyEvaluatorIntegrationTest
     then: 'the application is scanned and evaluated'
       1 * iqClient.verifyOrCreateApplication(*_) >> true
       1 * iqClient.scan(*_) >> new ScanResult(new Scan(), File.createTempFile('dummy-scan', '.xml.gz'))
-      1 * iqClient.evaluateApplication(*_) >> new ApplicationPolicyEvaluation(0, 1, 2, 3, 0, [],
+      1 * iqClient.evaluateApplication(*_) >> new ApplicationPolicyEvaluation(0, 1, 2, 3, 11, 12, 13, 0, [],
           'http://server/link/to/report')
 
     then: 'the expected result is returned'
@@ -208,9 +208,9 @@ class IqPolicyEvaluatorIntegrationTest
       with(build.getLog(100)) {
         it.contains('url:http://server/link/to/report')
         it.contains('affected:0')
-        it.contains('critical:1')
-        it.contains('severe:2')
-        it.contains('moderate:3')
+        it.contains('critical:11')
+        it.contains('severe:12')
+        it.contains('moderate:13')
         it.contains('alerts:[]')
       }
   }
@@ -228,7 +228,7 @@ class IqPolicyEvaluatorIntegrationTest
     then: 'the application is scanned and evaluated'
       1 * iqClient.verifyOrCreateApplication(*_) >> true
       1 * iqClient.scan(*_) >> new ScanResult(new Scan(), File.createTempFile('dummy-scan', '.xml.gz'))
-      1 * iqClient.evaluateApplication(*_) >> new ApplicationPolicyEvaluation(0, 1, 2, 3, 0, [],
+      1 * iqClient.evaluateApplication(*_) >> new ApplicationPolicyEvaluation(0, 1, 2, 3, 11, 12, 13, 0, [],
           'http://server/link/to/report')
 
     then: 'the return code is successful'
@@ -402,7 +402,7 @@ class IqPolicyEvaluatorIntegrationTest
     then: 'the application is scanned and evaluated'
       1 * iqClient.verifyOrCreateApplication(*_) >> true
       1 * iqClient.scan(*_) >> new ScanResult(new Scan(), File.createTempFile('dummy-scan', '.xml.gz'))
-      1 * iqClient.evaluateApplication(*_) >> new ApplicationPolicyEvaluation(0, 1, 2, 3, 0,
+      1 * iqClient.evaluateApplication(*_) >> new ApplicationPolicyEvaluation(0, 1, 2, 3, 11, 12, 13, 0,
           [createAlert(Action.ID_FAIL)], 'http://server/link/to/report')
 
     and: 'the build fails'
@@ -428,9 +428,9 @@ class IqPolicyEvaluatorIntegrationTest
               'def result = error.policyEvaluation \n' +
               'echo "url:" + result.applicationCompositionReportUrl\n' +
               'echo "affected:" + result.affectedComponentCount\n' +
-              'echo "critical:" + result.criticalComponentCount\n' +
-              'echo "severe:" + result.severeComponentCount\n' +
-              'echo "moderate:" + result.moderateComponentCount\n' +
+              'echo "critical:" + result.criticalPolicyViolationCount\n' +
+              'echo "severe:" + result.severePolicyViolationCount\n' +
+              'echo "moderate:" + result.moderatePolicyViolationCount\n' +
               'echo "url:" + result.applicationCompositionReportUrl\n' +
               'echo "alerts:" + result.policyAlerts' +
             '} \n' +
@@ -440,7 +440,7 @@ class IqPolicyEvaluatorIntegrationTest
     then: 'the application is scanned and evaluated'
       1 * iqClient.verifyOrCreateApplication(*_) >> true
       1 * iqClient.scan(*_) >> new ScanResult(new Scan(), File.createTempFile('dummy-scan', '.xml.gz'))
-      1 * iqClient.evaluateApplication(*_) >> new ApplicationPolicyEvaluation(0, 1, 2, 3, 0,
+      1 * iqClient.evaluateApplication(*_) >> new ApplicationPolicyEvaluation(0, 1, 2, 3, 11, 12, 13, 0,
           [createAlert(Action.ID_FAIL)], 'http://server/link/to/report')
 
     and: 'the build fails'
@@ -448,9 +448,9 @@ class IqPolicyEvaluatorIntegrationTest
       with(build.getLog(100)) {
         it.contains('url:http://server/link/to/report')
         it.contains('affected:0')
-        it.contains('critical:1')
-        it.contains('severe:2')
-        it.contains('moderate:3')
+        it.contains('critical:11')
+        it.contains('severe:12')
+        it.contains('moderate:13')
         it =~ /alerts:\[.+]/
       }
   }
@@ -470,7 +470,7 @@ class IqPolicyEvaluatorIntegrationTest
     then: 'the application is scanned and evaluated'
       1 * iqClient.verifyOrCreateApplication(*_) >> true
       1 * iqClient.scan(*_) >> new ScanResult(new Scan(), File.createTempFile('dummy-scan', '.xml.gz'))
-      1 * iqClient.evaluateApplication(*_) >> new ApplicationPolicyEvaluation(0, 1, 2, 3, 0,
+      1 * iqClient.evaluateApplication(*_) >> new ApplicationPolicyEvaluation(0, 1, 2, 3, 11, 12, 13, 0,
           [createAlert(Action.ID_FAIL)], 'http://server/link/to/report')
 
     then: 'the build fails'
@@ -607,7 +607,7 @@ class IqPolicyEvaluatorIntegrationTest
     then: 'the application is scanned and evaluated'
       1 * iqClient.verifyOrCreateApplication('app') >> true
       1 * iqClient.scan(*_) >> new ScanResult(new Scan(), File.createTempFile('dummy-scan', '.xml.gz'))
-      1 * iqClient.evaluateApplication('app', _, _, _) >> new ApplicationPolicyEvaluation(0, 1, 2, 3, 0, [],
+      1 * iqClient.evaluateApplication('app', _, _, _) >> new ApplicationPolicyEvaluation(0, 1, 2, 3, 11, 12, 13, 0, [],
           'http://server/link/to/report')
 
     then: 'the return code is successful'
@@ -632,7 +632,7 @@ class IqPolicyEvaluatorIntegrationTest
     then: 'the application is scanned and evaluated'
       1 * iqClient.verifyOrCreateApplication('app') >> true
       1 * iqClient.scan(*_) >> new ScanResult(new Scan(), File.createTempFile('dummy-scan', '.xml.gz'))
-      1 * iqClient.evaluateApplication('app', _, _, _) >> new ApplicationPolicyEvaluation(0, 1, 2, 3, 0, [],
+      1 * iqClient.evaluateApplication('app', _, _, _) >> new ApplicationPolicyEvaluation(0, 1, 2, 3, 11, 12, 13, 0, [],
           'http://server/link/to/report')
 
     then: 'the return code is successful'
@@ -657,7 +657,7 @@ class IqPolicyEvaluatorIntegrationTest
     then: 'the application is scanned and evaluated'
       1 * iqClient.verifyOrCreateApplication(*_) >> true
       1 * iqClient.scan(*_) >> new ScanResult(new Scan(), File.createTempFile('dummy-scan', '.xml.gz'))
-      1 * iqClient.evaluateApplication(*_) >> new ApplicationPolicyEvaluation(0, 1, 2, 3, 0, [],
+      1 * iqClient.evaluateApplication(*_) >> new ApplicationPolicyEvaluation(0, 1, 2, 3, 11, 12, 13, 0, [],
           'http://server/link/to/report')
 
     and: 'the source control onboarding is called with the repo url'
@@ -680,7 +680,7 @@ class IqPolicyEvaluatorIntegrationTest
     then: 'the application is scanned and evaluated'
       1 * iqClient.verifyOrCreateApplication(*_) >> true
       1 * iqClient.scan(*_) >> new ScanResult(new Scan(), File.createTempFile('dummy-scan', '.xml.gz'))
-      1 * iqClient.evaluateApplication(*_) >> new ApplicationPolicyEvaluation(0, 0, 0, 0, 0, [],
+      1 * iqClient.evaluateApplication(*_) >> new ApplicationPolicyEvaluation(0, 0, 0, 0, 0, 0, 0, 0, [],
           'http://server/link/to/report')
 
     and: 'the source control onboarding is called with the repo url'
@@ -701,7 +701,7 @@ class IqPolicyEvaluatorIntegrationTest
     then: 'the application is scanned and evaluated'
       1 * iqClient.verifyOrCreateApplication(*_) >> true
       1 * iqClient.scan(*_) >> new ScanResult(new Scan(), File.createTempFile('dummy-scan', '.xml.gz'))
-      1 * iqClient.evaluateApplication(*_) >> new ApplicationPolicyEvaluation(0, 1, 2, 3, 0, [],
+      1 * iqClient.evaluateApplication(*_) >> new ApplicationPolicyEvaluation(0, 1, 2, 3, 11, 12, 13, 0, [],
           'http://server/link/to/report')
 
     and: 'the source control onboarding is not called'
@@ -739,7 +739,7 @@ class IqPolicyEvaluatorIntegrationTest
       1 * iqClient.verifyOrCreateApplication('app') >> true
       1 * iqClient.scan(*_) >> new ScanResult(new Scan(), File.createTempFile('dummy-scan', '.xml.gz'))
       1 * iqClient.evaluateApplication(*_) >>
-          new ApplicationPolicyEvaluation(0, 1, 2, 3, 0, [], 'http://server/link/to/report')
+          new ApplicationPolicyEvaluation(0, 1, 2, 3, 11, 12, 13, 0, [], 'http://server/link/to/report')
 
     and: 'the source control onboarding is called with the repo url'
       1 * iqClient.addOrUpdateSourceControl('app', url)
@@ -766,7 +766,7 @@ class IqPolicyEvaluatorIntegrationTest
       1 * iqClient.verifyOrCreateApplication('app') >> true
       1 * iqClient.scan(*_) >> new ScanResult(new Scan(), File.createTempFile('dummy-scan', '.xml.gz'))
       1 * iqClient.evaluateApplication(*_) >>
-          new ApplicationPolicyEvaluation(0, 1, 2, 3, 0, [], 'http://server/link/to/report')
+          new ApplicationPolicyEvaluation(0, 1, 2, 3, 11, 12, 13, 0, [], 'http://server/link/to/report')
 
     and: 'the source control onboarding is called with the repo url'
       jenkins.assertBuildStatusSuccess(build)
@@ -798,7 +798,7 @@ class IqPolicyEvaluatorIntegrationTest
       1 * iqClient.verifyOrCreateApplication('app') >> true
       1 * iqClient.scan(*_) >> new ScanResult(new Scan(), File.createTempFile('dummy-scan', '.xml.gz'))
       1 * iqClient.evaluateApplication(*_) >>
-          new ApplicationPolicyEvaluation(0, 1, 2, 3, 0, [], 'http://server/link/to/report')
+          new ApplicationPolicyEvaluation(0, 1, 2, 3, 11, 12, 13, 0, [], 'http://server/link/to/report')
 
     and: 'the source control onboarding is not called'
       //When running tests as part of a CI build, the workspace will be in the git context of the checked out CI

--- a/src/test/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorSlaveIntegrationTest.groovy
+++ b/src/test/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorSlaveIntegrationTest.groovy
@@ -75,9 +75,9 @@ class IqPolicyEvaluatorSlaveIntegrationTest
         "result": {
         "alerts": [],
         "affectedComponentCount": 33,
-        "criticalComponentCount": 20,
-        "severeComponentCount": 12,
-        "moderateComponentCount": 1,
+        "criticalPolicyViolationCount": 20,
+        "severePolicyViolationCount": 12,
+        "moderatePolicyViolationCount": 1,
         "criticalPolicyViolationCount": 46,
         "severePolicyViolationCount": 54,
         "moderatePolicyViolationCount": 3,

--- a/src/test/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorTest.groovy
+++ b/src/test/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorTest.groovy
@@ -83,7 +83,7 @@ class IqPolicyEvaluatorTest
     NxiqConfiguration.serverUrl >> URI.create("http://server/path")
     NxiqConfiguration.credentialsId >> '123-cred-456'
     GlobalNexusConfiguration.instanceId >> 'instance-id'
-    iqClient.evaluateApplication("appId", "stage", _, _) >> new ApplicationPolicyEvaluation(0, 0, 0, 0, 0, [],
+    iqClient.evaluateApplication("appId", "stage", _, _) >> new ApplicationPolicyEvaluation(0, 0, 0, 0, 0, 0, 0, 0, [],
         reportUrl)
     IqClientFactory.getIqClient(*_) >> iqClient
     remoteScanResult.copyToLocalScanResult() >> scanResult
@@ -98,7 +98,7 @@ class IqPolicyEvaluatorTest
     setup:
       def buildStep = new IqPolicyEvaluatorBuildStep("stage", new SelectedApplication('appId'), [new ScanPattern("*.jar")], [],
           false, null, null)
-      def evaluationResult = new ApplicationPolicyEvaluation(0, 0, 0, 0, 0, emptyList(), reportUrl)
+      def evaluationResult = new ApplicationPolicyEvaluation(0, 0, 0, 0, 0, 0, 0, 0, emptyList(), reportUrl)
       def remoteScanner = Mock(RemoteScanner)
 
     when:
@@ -293,7 +293,7 @@ class IqPolicyEvaluatorTest
     then:
       1 * iqClient.verifyOrCreateApplication(*_) >> true
       1 * iqClient.evaluateApplication('appId', 'stage', scanResult, _) >>
-          new ApplicationPolicyEvaluation(0, 0, 0, 0, 0, alerts, reportUrl)
+          new ApplicationPolicyEvaluation(0, 0, 0, 0, 0, 0, 0, 0, alerts, reportUrl)
       1 * run.setResult(buildResult)
 
     where:
@@ -307,7 +307,7 @@ class IqPolicyEvaluatorTest
     setup:
       def buildStep = new IqPolicyEvaluatorBuildStep('stage', new SelectedApplication('appId'), [new ScanPattern('*.jar')], [],
           false, '131-cred', null)
-      def policyEvaluation = new ApplicationPolicyEvaluation(0, 0, 0, 0, 0,
+      def policyEvaluation = new ApplicationPolicyEvaluation(0, 0, 0, 0, 0, 0, 0, 0,
           [new PolicyAlert(null, [new Action(Action.ID_FAIL)])], reportUrl)
 
     when:
@@ -339,7 +339,7 @@ class IqPolicyEvaluatorTest
     then:
       1 * iqClient.verifyOrCreateApplication(*_) >> true
       1 * iqClient.evaluateApplication('appId', 'stage', scanResult, _) >>
-          new ApplicationPolicyEvaluation(0, 1, 2, 3, 0, [new PolicyAlert(trigger, [new Action(Action.ID_FAIL)])],
+          new ApplicationPolicyEvaluation(0, 1, 2, 3, 11, 12, 13, 0, [new PolicyAlert(trigger, [new Action(Action.ID_FAIL)])],
               reportUrl)
 
     and:
@@ -347,7 +347,7 @@ class IqPolicyEvaluatorTest
       1 * log.println(
           'Nexus IQ reports policy failing due to \nPolicy(policyName) [\n Component(displayName=value, ' +
               'hash=12hash34) [\n  Constraint(constraintName) [summary because: reason] ]]\nThe detailed report can be' +
-              ' viewed online at http://server/report\nSummary of policy violations: 1 critical, 2 severe, 3 moderate')
+              ' viewed online at http://server/report\nSummary of policy violations: 11 critical, 12 severe, 13 moderate')
       1 * listener.fatalError('IQ Server evaluation of application appId failed')
   }
 
@@ -366,13 +366,13 @@ class IqPolicyEvaluatorTest
     then:
       1 * iqClient.verifyOrCreateApplication(*_) >> true
       1 * iqClient.evaluateApplication('appId', 'stage', scanResult, _) >>
-          new ApplicationPolicyEvaluation(0, 1, 2, 3, 0, [new PolicyAlert(trigger, [new Action(Action.ID_WARN)])],
+          new ApplicationPolicyEvaluation(0, 1, 2, 3, 11, 12, 13, 0, [new PolicyAlert(trigger, [new Action(Action.ID_WARN)])],
               reportUrl)
       1 * log.println("IQ Server evaluation of application appId detected warnings")
       1 * log.println(
           'Nexus IQ reports policy warning due to \nPolicy(policyName) [\n Component(displayName=value, ' +
               'hash=12hash34) [\n  Constraint(constraintName) [summary because: reason] ]]\nThe detailed report can be' +
-              ' viewed online at http://server/report\nSummary of policy violations: 1 critical, 2 severe, 3 moderate')
+              ' viewed online at http://server/report\nSummary of policy violations: 11 critical, 12 severe, 13 moderate')
   }
 
   def 'prints a summary on success'() {
@@ -389,7 +389,7 @@ class IqPolicyEvaluatorTest
     then:
       1 * iqClient.verifyOrCreateApplication(*_) >> true
       1 * iqClient.evaluateApplication('appId', 'stage', scanResult, _) >>
-          new ApplicationPolicyEvaluation(0, 0, 0, 0, 0, [],
+          new ApplicationPolicyEvaluation(0, 0, 0, 0, 0, 0, 0, 0, [],
               reportUrl)
       0 * log.println("WARNING: IQ Server evaluation of application appId detected warnings.")
       1 * log.println('\nThe detailed report can be viewed online at http://server/report\n' +
@@ -416,7 +416,7 @@ class IqPolicyEvaluatorTest
       def buildStep = new IqPolicyEvaluatorBuildStep("stage", new SelectedApplication('appId'),
           [new ScanPattern("*.jar")], [],
           false, null, null)
-      def evaluationResult = new ApplicationPolicyEvaluation(0, 0, 0, 0, 0, emptyList(), reportUrl)
+      def evaluationResult = new ApplicationPolicyEvaluation(0, 0, 0, 0, 0, 0, 0, 0, emptyList(), reportUrl)
       def remoteScanner = Mock(RemoteScanner)
 
     when:

--- a/src/test/java/org/sonatype/nexus/ci/iq/PolicyEvaluationHealthActionTest.groovy
+++ b/src/test/java/org/sonatype/nexus/ci/iq/PolicyEvaluationHealthActionTest.groovy
@@ -25,7 +25,7 @@ class PolicyEvaluationHealthActionTest
   def 'it redirects to the application composition report'() {
     setup:
       def reportLink = 'http://localhost/reportLink'
-      def policyEvaluation = new ApplicationPolicyEvaluation(0, 0, 0, 0, 0, [], reportLink)
+      def policyEvaluation = new ApplicationPolicyEvaluation(0, 0, 0, 0, 0, 0, 0, 0, [], reportLink)
       def healthAction = new PolicyEvaluationHealthAction('appId', 'stage', null, policyEvaluation)
       def response = Mock(StaplerResponse)
 
@@ -79,15 +79,15 @@ class PolicyEvaluationHealthActionTest
   def 'it returns the correct component and grandfathered policy violation counts'() {
     setup:
       def reportLink = 'http://localhost/reportLink'
-      def policyEvaluation = new ApplicationPolicyEvaluation(1, 2, 3, 4, 5, [], reportLink)
+      def policyEvaluation = new ApplicationPolicyEvaluation(1, 2, 3, 4, 11, 12, 13, 5, [], reportLink)
       def healthAction = new PolicyEvaluationHealthAction('my-iq-app', 'build', null, policyEvaluation)
       def response = Mock(StaplerResponse)
 
     when: 'getting component and grandfathered policy violation counts'
       def affectedComponentCount = healthAction.affectedComponentCount
-      def criticalComponentCount = healthAction.criticalComponentCount
-      def severeComponentCount = healthAction.severeComponentCount
-      def moderateComponentCount = healthAction.moderateComponentCount
+      def criticalPolicyViolationCount = healthAction.criticalPolicyViolationCount
+      def severePolicyViolationCount = healthAction.severePolicyViolationCount
+      def moderatePolicyViolationCount = healthAction.moderatePolicyViolationCount
       def grandfatheredPolicyViolationCount = healthAction.grandfatheredPolicyViolationCount
       def urlName = healthAction.urlName
       def appId = healthAction.applicationId
@@ -95,9 +95,9 @@ class PolicyEvaluationHealthActionTest
 
     then:
       affectedComponentCount == 1
-      criticalComponentCount == 2
-      severeComponentCount == 3
-      moderateComponentCount == 4
+      criticalPolicyViolationCount == 11
+      severePolicyViolationCount == 12
+      moderatePolicyViolationCount == 13
       grandfatheredPolicyViolationCount == 5
       urlName == reportLink
       appId == 'my-iq-app'
@@ -108,7 +108,7 @@ class PolicyEvaluationHealthActionTest
     setup:
       def reportLink = 'http://localhost/reportLink'
       def run = Mock(Run)
-      def policyEvaluation = new ApplicationPolicyEvaluation(1, 2, 3, 4, 5, [], reportLink)
+      def policyEvaluation = new ApplicationPolicyEvaluation(1, 2, 3, 4, 11, 12, 13, 5, [], reportLink)
       def healthAction = new PolicyEvaluationHealthAction('appId', 'stage', run, policyEvaluation)
 
     when:

--- a/src/test/java/org/sonatype/nexus/ci/iq/PolicyEvaluationReportActionTest.groovy
+++ b/src/test/java/org/sonatype/nexus/ci/iq/PolicyEvaluationReportActionTest.groovy
@@ -63,7 +63,7 @@ class PolicyEvaluationReportActionTest
   def "GetUrl"() {
     setup:
       def reportLink = 'http://localhost/reportLink'
-      def policyEvaluation = new ApplicationPolicyEvaluation(1, 2, 3, 4, 5, [], reportLink)
+      def policyEvaluation = new ApplicationPolicyEvaluation(1, 2, 3, 4, 11, 12, 13, 5, [], reportLink)
       def reportAction = new PolicyEvaluationReportAction('my-iq-app', 'build', null, policyEvaluation)
     when: 'getting report URL'
       def url = reportAction.getUrl()
@@ -74,7 +74,7 @@ class PolicyEvaluationReportActionTest
   def "GetReport should return empty report object"() {
     setup:
       def reportLink = 'http://localhost/reportLink'
-      def policyEvaluation = new ApplicationPolicyEvaluation(1, 2, 3, 4, 5, [], reportLink)
+      def policyEvaluation = new ApplicationPolicyEvaluation(1, 2, 3, 4, 11, 12, 13, 5, [], reportLink)
       def reportAction = new PolicyEvaluationReportAction('my-iq-app', 'build', null, policyEvaluation)
 
     when: 'getting report result from empty object'
@@ -99,7 +99,7 @@ class PolicyEvaluationReportActionTest
       def alertWarn2 = new PolicyAlert(fact, [new Action('warn', '', '')])
       def alertNoAction = new PolicyAlert(fact, [])
 
-      def policyEvaluation = new ApplicationPolicyEvaluation(1, 2, 3, 4, 5,
+      def policyEvaluation = new ApplicationPolicyEvaluation(1, 2, 3, 4, 11, 12, 13, 5,
           [alertFail, alertWarn, alertWarn2, alertNoAction], 'link')
       def reportAction = new PolicyEvaluationReportAction('my-iq-app', 'build', null, policyEvaluation)
 

--- a/src/test/java/org/sonatype/nexus/ci/iq/PolicyFailureMessageFormatterTest.groovy
+++ b/src/test/java/org/sonatype/nexus/ci/iq/PolicyFailureMessageFormatterTest.groovy
@@ -85,7 +85,7 @@ class PolicyFailureMessageFormatterTest
           ' hash=12hash34) [\n  Constraint(constraintName) [summary because: reason] ]]\n\nNexus IQ reports ' +
           'policy warning due to \nPolicy(policyName) [\n Component(displayName=value, hash=12hash34) [\n  ' +
           'Constraint(constraintName) [summary because: reason] ]]\nThe detailed report can be viewed online at ' +
-          'http://report/url\nSummary of policy violations: 2 critical, 3 severe, 5 moderate'
+          'http://report/url\nSummary of policy violations: 11 critical, 12 severe, 13 moderate'
   }
 
   def 'creates success report'() {
@@ -94,10 +94,10 @@ class PolicyFailureMessageFormatterTest
 
     then:
       successFormatter.message == '\nThe detailed report can be viewed online at http://report/url\nSummary of ' +
-          'policy violations: 2 critical, 3 severe, 5 moderate'
+          'policy violations: 11 critical, 12 severe, 13 moderate'
   }
 
   ApplicationPolicyEvaluation createFullModel(List<PolicyAlert> alerts) {
-    return new ApplicationPolicyEvaluation(1, 2, 3, 5, 0, alerts, 'http://report/url')
+    return new ApplicationPolicyEvaluation(1, 2, 3, 5, 11, 12, 13, 0, alerts, 'http://report/url')
   }
 }


### PR DESCRIPTION
#### Description
The purpose of this change is to use policy violation counts in the violation summary, instead of component counts.

#### Links
Jira: https://issues.sonatype.org/browse/INT-2832
Build: https://jenkins.ci.sonatype.dev/job/integrations/job/jenkins/job/nexus-platform-plugin-feature/job/INT-2832-use-violation-counts/

**Note**: The build on https://ci.jenkins.io will not pass until we release `nexus-java-api`, which will be done shortly after this PR is approved.