### PR TITLE
Refined policy evaluation summary section, based on product feedback

### DIFF
--- a/src/main/java/org/sonatype/nexus/ci/iq/PolicyEvaluationHealthAction.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/iq/PolicyEvaluationHealthAction.groovy
@@ -75,6 +75,14 @@ class PolicyEvaluationHealthAction
     return moderatePolicyViolationCount
   }
 
+  int getTotalPolicyViolationCount() {
+    return criticalPolicyViolationCount + severePolicyViolationCount + moderatePolicyViolationCount
+  }
+
+  int getAffectedComponentCount() {
+    return affectedComponentCount
+  }
+
   int getGrandfatheredPolicyViolationCount() {
     return grandfatheredPolicyViolationCount
   }

--- a/src/main/resources/org/sonatype/nexus/ci/iq/Messages.properties
+++ b/src/main/resources/org/sonatype/nexus/ci/iq/Messages.properties
@@ -43,6 +43,8 @@ IqPolicyEvaluation.ApplicationLabel=Application
 IqPolicyEvaluation.StageLabel=IQ Stage
 IqPolicyEvaluation.NoViolations=No Violations
 IqPolicyEvaluation.NumberGrandfathered={0} grandfathered
+IqPolicyEvaluation.TotalViolations={0} Violations
+IqPolicyEvaluation.AffectedComponents=affecting {0} components
 
 PolicyFailureMessageFormatter.PolicyFailing=Nexus IQ reports policy failing due to {0}
 PolicyFailureMessageFormatter.PolicyWarning=Nexus IQ reports policy warning due to {0}

--- a/src/main/resources/org/sonatype/nexus/ci/iq/PolicyEvaluationHealthAction/summary.groovy
+++ b/src/main/resources/org/sonatype/nexus/ci/iq/PolicyEvaluationHealthAction/summary.groovy
@@ -79,7 +79,7 @@ def policyCss = {
         }
         
         .iq-chiclet-message {
-          margin-left: 3px;
+          margin-left: 0.4em;
           padding-top: 2px;
         }
       """)
@@ -102,11 +102,19 @@ def policyUI = {
       }
     }
     div(class: 'p-iq-chiclet') {
-      span(class: 'iq-chiclet critical', action.criticalPolicyViolationCount ? action.criticalPolicyViolationCount : 0)
-      span(class: 'iq-chiclet severe', action.severePolicyViolationCount ? action.severePolicyViolationCount : 0)
-      span(class: 'iq-chiclet moderate', action.moderatePolicyViolationCount ? action.moderatePolicyViolationCount : 0)
+      span(class: 'iq-label', Messages.IqPolicyEvaluation_TotalViolations(action.totalPolicyViolationCount))
       span(class: 'iq-chiclet-message',
-          Messages.IqPolicyEvaluation_NumberGrandfathered(action.grandfatheredPolicyViolationCount))
+          Messages.IqPolicyEvaluation_AffectedComponents(action.affectedComponentCount))
+    }
+    div(class: 'p-iq-chiclet') {
+      span(class: 'iq-chiclet critical',
+          action.criticalPolicyViolationCount ? action.criticalPolicyViolationCount : 0)
+      span(class: 'iq-chiclet severe', action.severePolicyViolationCount ? action.severePolicyViolationCount : 0)
+      span(class: 'iq-chiclet moderate',
+          action.moderatePolicyViolationCount ? action.moderatePolicyViolationCount : 0)
+    }
+    div(class: 'p-iq-chiclet') {
+      span(Messages.IqPolicyEvaluation_NumberGrandfathered(action.grandfatheredPolicyViolationCount))
     }
   }
 }

--- a/src/main/resources/org/sonatype/nexus/ci/iq/PolicyEvaluationProjectAction/jobMain.groovy
+++ b/src/main/resources/org/sonatype/nexus/ci/iq/PolicyEvaluationProjectAction/jobMain.groovy
@@ -108,7 +108,7 @@ if (action) {
         }
         
         .iq-chiclet-message {
-          margin-left: 3px;
+          margin-left: 0.4em;
           padding-top: 2px;
         }
       """)
@@ -131,11 +131,19 @@ if (action) {
         }
       }
       div(class: 'p-iq-chiclet') {
-        span(class: 'iq-chiclet critical', action.criticalPolicyViolationCount ? action.criticalPolicyViolationCount : 0)
-        span(class: 'iq-chiclet severe', action.severePolicyViolationCount ? action.severePolicyViolationCount : 0)
-        span(class: 'iq-chiclet moderate', action.moderatePolicyViolationCount ? action.moderatePolicyViolationCount : 0)
+        span(class: 'iq-label', Messages.IqPolicyEvaluation_TotalViolations(action.totalPolicyViolationCount))
         span(class: 'iq-chiclet-message',
-            Messages.IqPolicyEvaluation_NumberGrandfathered(action.grandfatheredPolicyViolationCount))
+            Messages.IqPolicyEvaluation_AffectedComponents(action.affectedComponentCount))
+      }
+      div(class: 'p-iq-chiclet') {
+        span(class: 'iq-chiclet critical',
+            action.criticalPolicyViolationCount ? action.criticalPolicyViolationCount : 0)
+        span(class: 'iq-chiclet severe', action.severePolicyViolationCount ? action.severePolicyViolationCount : 0)
+        span(class: 'iq-chiclet moderate',
+            action.moderatePolicyViolationCount ? action.moderatePolicyViolationCount : 0)
+      }
+      div(class: 'p-iq-chiclet') {
+        span(Messages.IqPolicyEvaluation_NumberGrandfathered(action.grandfatheredPolicyViolationCount))
       }
     }
   }

--- a/src/test/java/org/sonatype/nexus/ci/iq/PolicyEvaluationHealthActionTest.groovy
+++ b/src/test/java/org/sonatype/nexus/ci/iq/PolicyEvaluationHealthActionTest.groovy
@@ -89,6 +89,7 @@ class PolicyEvaluationHealthActionTest
       def severePolicyViolationCount = healthAction.severePolicyViolationCount
       def moderatePolicyViolationCount = healthAction.moderatePolicyViolationCount
       def grandfatheredPolicyViolationCount = healthAction.grandfatheredPolicyViolationCount
+      def totalPolicyViolationCount = healthAction.totalPolicyViolationCount
       def urlName = healthAction.urlName
       def appId = healthAction.applicationId
       def iqStage = healthAction.iqStage
@@ -98,6 +99,7 @@ class PolicyEvaluationHealthActionTest
       criticalPolicyViolationCount == 11
       severePolicyViolationCount == 12
       moderatePolicyViolationCount == 13
+      totalPolicyViolationCount == 36
       grandfatheredPolicyViolationCount == 5
       urlName == reportLink
       appId == 'my-iq-app'


### PR DESCRIPTION
Refined policy evaluation summary section based on product feedback. 

Now it looks like this:
![jen-03](https://user-images.githubusercontent.com/49167996/85063896-cd7dff80-b178-11ea-98ad-3794d0292925.png)



Jira: https://issues.sonatype.org/browse/INT-2832
Build: https://jenkins.ci.sonatype.dev/job/integrations/job/jenkins/job/nexus-platform-plugin-feature/job/INT-2832-use-violation-counts-take-2/
