### PR TITLE
INT-2878 Remove jsr305

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,13 @@
         <artifactId>nexus-platform-api</artifactId>
         <version>3.15</version>
         <classifier>internal</classifier>
+        <!-- TODO 3.16 won't have the transitive anymore, do we still need this? -->
+        <exclusions>
+          <exclusion>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <!-- bcprov-jdk15on versions before 1.60 have a lot of security vulnerabilities. -->
@@ -169,6 +176,30 @@
         <groupId>com.github.tomakehurst</groupId>
         <artifactId>wiremock-standalone</artifactId>
         <version>2.14.0</version>
+      </dependency>
+
+      <!-- Override from parent to exclude jsr305 -->
+      <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava</artifactId>
+        <exclusions>
+          <exclusion>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+
+      <!-- Override from parent to exclude jsr305 -->
+      <dependency>
+        <groupId>org.kohsuke.stapler</groupId>
+        <artifactId>stapler-jrebel</artifactId>
+        <exclusions>
+          <exclusion>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -293,6 +324,12 @@
       <artifactId>pipeline-model-definition</artifactId>
       <version>1.2.7</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.code.findbugs</groupId>
+          <artifactId>jsr305</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <!-- End Jenkins plugins -->
   </dependencies>
@@ -336,6 +373,11 @@
                   <ignoredScope>test</ignoredScope>
                 </ignoredScopes>
               </enforceBytecodeVersion>
+              <bannedDependencies>
+                <excludes>
+                  <exclude>com.google.code.findbugs:jsr305</exclude>
+                </excludes>
+              </bannedDependencies>
             </rules>
           </configuration>
         </plugin>

--- a/src/main/java/org/sonatype/nexus/ci/config/GlobalNexusConfiguration.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/config/GlobalNexusConfiguration.groovy
@@ -12,8 +12,6 @@
  */
 package org.sonatype.nexus.ci.config
 
-import javax.annotation.Nullable
-
 import hudson.Extension
 import hudson.model.Descriptor
 import jenkins.model.GlobalConfiguration
@@ -59,7 +57,7 @@ class GlobalNexusConfiguration
     return 'Sonatype Nexus'
   }
 
-  static @Nullable getGlobalNexusConfiguration() {
+  static getGlobalNexusConfiguration() {
     return all().get(GlobalNexusConfiguration)
   }
 

--- a/src/main/java/org/sonatype/nexus/ci/config/NxiqConfiguration.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/config/NxiqConfiguration.groovy
@@ -12,8 +12,6 @@
  */
 package org.sonatype.nexus.ci.config
 
-import javax.annotation.Nullable
-
 import org.sonatype.nexus.ci.util.FormUtil
 import org.sonatype.nexus.ci.util.IqUtil
 
@@ -49,16 +47,16 @@ class NxiqConfiguration
     return Jenkins.getInstance().getDescriptorOrDie(this.getClass())
   }
 
-  static @Nullable URI getServerUrl() {
+  static URI getServerUrl() {
     def serverUrl = getIqConfig()?.@serverUrl
     serverUrl ? new URI(serverUrl) : null
   }
 
-  static @Nullable String getCredentialsId() {
+  static String getCredentialsId() {
     getIqConfig()?.@credentialsId
   }
 
-  static @Nullable NxiqConfiguration getIqConfig() {
+  static NxiqConfiguration getIqConfig() {
     return GlobalNexusConfiguration.globalNexusConfiguration.iqConfigs?.find { true }
   }
 
@@ -89,7 +87,7 @@ class NxiqConfiguration
     @SuppressWarnings('unused')
     FormValidation doVerifyCredentials(
         @QueryParameter String serverUrl,
-        @QueryParameter @Nullable String credentialsId) throws IOException
+        @QueryParameter String credentialsId) throws IOException
     {
       return IqUtil.verifyJobCredentials(serverUrl, credentialsId, Jenkins.instance)
     }

--- a/src/main/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorBuildStep.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorBuildStep.groovy
@@ -12,10 +12,6 @@
  */
 package org.sonatype.nexus.ci.iq
 
-import javax.annotation.Nonnull
-import javax.annotation.Nullable
-import javax.annotation.ParametersAreNonnullByDefault
-
 import org.sonatype.nexus.ci.config.NxiqConfiguration
 import org.sonatype.nexus.ci.util.FormUtil
 import org.sonatype.nexus.ci.util.IqUtil
@@ -35,7 +31,6 @@ import org.kohsuke.stapler.AncestorInPath
 import org.kohsuke.stapler.DataBoundConstructor
 import org.kohsuke.stapler.QueryParameter
 
-@ParametersAreNonnullByDefault
 class IqPolicyEvaluatorBuildStep
     extends Builder
     implements IqPolicyEvaluator, BuildStep
@@ -74,7 +69,7 @@ class IqPolicyEvaluatorBuildStep
   }
 
   @Override
-  boolean perform(@Nonnull AbstractBuild run, @Nonnull Launcher launcher, @Nonnull BuildListener listener)
+  boolean perform(AbstractBuild run, Launcher launcher, BuildListener listener)
       throws InterruptedException, IOException
   {
     IqPolicyEvaluatorUtil.
@@ -136,7 +131,7 @@ class IqPolicyEvaluatorBuildStep
     }
 
     @Override
-    FormValidation doVerifyCredentials(@QueryParameter @Nullable String jobCredentialsId, @AncestorInPath Job job)
+    FormValidation doVerifyCredentials(@QueryParameter String jobCredentialsId, @AncestorInPath Job job)
     {
       IqUtil.verifyJobCredentials(jobCredentialsId, job)
     }

--- a/src/main/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorWorkflowStep.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorWorkflowStep.groovy
@@ -12,9 +12,6 @@
  */
 package org.sonatype.nexus.ci.iq
 
-import javax.annotation.Nullable
-import javax.annotation.ParametersAreNonnullByDefault
-
 import org.sonatype.nexus.ci.config.NxiqConfiguration
 import org.sonatype.nexus.ci.util.FormUtil
 import org.sonatype.nexus.ci.util.IqUtil
@@ -31,7 +28,6 @@ import org.kohsuke.stapler.DataBoundConstructor
 import org.kohsuke.stapler.DataBoundSetter
 import org.kohsuke.stapler.QueryParameter
 
-@ParametersAreNonnullByDefault
 class IqPolicyEvaluatorWorkflowStep
     extends AbstractStepImpl
     implements IqPolicyEvaluator
@@ -123,7 +119,7 @@ class IqPolicyEvaluatorWorkflowStep
     }
 
     @Override
-    ListBoxModel doFillIqStageItems(@QueryParameter @Nullable String jobCredentialsId, @AncestorInPath Job job) {
+    ListBoxModel doFillIqStageItems(@QueryParameter String jobCredentialsId, @AncestorInPath Job job) {
       IqUtil.doFillIqStageItems(jobCredentialsId, job)
     }
 
@@ -154,7 +150,7 @@ class IqPolicyEvaluatorWorkflowStep
     }
 
     @Override
-    FormValidation doVerifyCredentials(@QueryParameter @Nullable String jobCredentialsId, @AncestorInPath Job job)
+    FormValidation doVerifyCredentials(@QueryParameter String jobCredentialsId, @AncestorInPath Job job)
     {
       IqUtil.verifyJobCredentials(jobCredentialsId, job)
     }

--- a/src/main/java/org/sonatype/nexus/ci/nxrm/ComponentUploader.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/nxrm/ComponentUploader.groovy
@@ -12,8 +12,6 @@
  */
 package org.sonatype.nexus.ci.nxrm
 
-import javax.annotation.Nullable
-
 import org.sonatype.nexus.ci.config.NxrmConfiguration
 
 import hudson.EnvVars
@@ -45,15 +43,15 @@ abstract class ComponentUploader
 
   protected abstract void upload(final Map<MavenCoordinate, List<RemoteMavenAsset>> remoteMavenComponents,
                                  final String nxrmRepositoryId,
-                                 @Nullable final String tagName = null)
+                                 final String tagName = null)
 
   @SuppressWarnings(['UnusedMethodParameter', 'EmptyMethodInAbstractClass'])
-  void maybeCreateTag(@Nullable final String tagName) {
+  void maybeCreateTag(final String tagName) {
   }
 
   void uploadComponents(final NexusPublisher nexusPublisher,
                         final FilePath filePath,
-                        @Nullable final String tagName = null)
+                        final String tagName = null)
   {
     def mavenPackages = getPackagesOfType(nexusPublisher.packages, MavenPackage)
     def remoteMavenComponents = [:]

--- a/src/main/java/org/sonatype/nexus/ci/nxrm/v2/ComponentUploaderNxrm2.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/nxrm/v2/ComponentUploaderNxrm2.groovy
@@ -12,8 +12,6 @@
  */
 package org.sonatype.nexus.ci.nxrm.v2
 
-import javax.annotation.Nullable
-
 import com.sonatype.nexus.api.exception.RepositoryManagerException
 import com.sonatype.nexus.api.repository.v2.GAV
 import com.sonatype.nexus.api.repository.v2.MavenAsset
@@ -40,7 +38,7 @@ class ComponentUploaderNxrm2
   @Override
   void upload(final Map<MavenCoordinate, List<RemoteMavenAsset>> remoteMavenComponents,
               final String nxrmRepositoryId,
-              @Nullable final String tag = null)
+              final String tag = null)
   {
     def nxrmClient = getRepositoryManagerClient(nxrmConfiguration)
 

--- a/src/main/java/org/sonatype/nexus/ci/nxrm/v3/ComponentUploaderNxrm3.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/nxrm/v3/ComponentUploaderNxrm3.groovy
@@ -12,8 +12,6 @@
  */
 package org.sonatype.nexus.ci.nxrm.v3
 
-import javax.annotation.Nullable
-
 import com.sonatype.nexus.api.exception.RepositoryManagerException
 import com.sonatype.nexus.api.repository.v3.DefaultAsset
 import com.sonatype.nexus.api.repository.v3.RepositoryManagerV3Client
@@ -37,7 +35,7 @@ class ComponentUploaderNxrm3
     extends ComponentUploader
 {
   @Override
-  void maybeCreateTag(@Nullable final String tagName) {
+  void maybeCreateTag(final String tagName) {
     def resolvedTagName = envVars.expand(tagName)
     if (resolvedTagName?.trim()) {
       def nxrmClient = getRepositoryManagerClient(nxrmConfiguration)
@@ -48,7 +46,7 @@ class ComponentUploaderNxrm3
   @Override
   void upload(final Map<MavenCoordinate, List<RemoteMavenAsset>> remoteMavenComponents,
               final String nxrmRepositoryId,
-              @Nullable final String tagName = null)
+              final String tagName = null)
   {
     def nxrmClient = getRepositoryManagerClient(nxrmConfiguration)
 

--- a/src/main/java/org/sonatype/nexus/ci/util/IqUtil.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/util/IqUtil.groovy
@@ -12,8 +12,6 @@
  */
 package org.sonatype.nexus.ci.util
 
-import javax.annotation.Nullable
-
 import com.sonatype.nexus.api.exception.IqClientException
 import com.sonatype.nexus.api.iq.ApplicationSummary
 import com.sonatype.nexus.api.iq.Context
@@ -42,7 +40,7 @@ class IqUtil
     return client.getApplicationsForApplicationEvaluation()
   }
 
-  static ListBoxModel doFillIqStageItems(@Nullable final String credentialsId, final Job job) {
+  static ListBoxModel doFillIqStageItems(final String credentialsId, final Job job) {
     if (NxiqConfiguration.iqConfig) {
       def client = IqClientFactory.
           getIqClient(new IqClientFactoryConfiguration(credentialsId: credentialsId, context: job))
@@ -53,7 +51,7 @@ class IqUtil
     }
   }
 
-  static ListBoxModel doFillIqApplicationItems(@Nullable final String credentialsId, final Job job) {
+  static ListBoxModel doFillIqApplicationItems(final String credentialsId, final Job job) {
     if (NxiqConfiguration.iqConfig) {
       def client = IqClientFactory.
           getIqClient(new IqClientFactoryConfiguration(credentialsId: credentialsId, context: job))

--- a/src/main/java/org/sonatype/nexus/ci/util/RepositoryManagerClientUtil.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/util/RepositoryManagerClientUtil.groovy
@@ -12,8 +12,6 @@
  */
 package org.sonatype.nexus.ci.util
 
-import javax.annotation.Nullable
-
 import com.sonatype.nexus.api.common.Authentication
 import com.sonatype.nexus.api.common.ServerConfig
 import com.sonatype.nexus.api.exception.RepositoryManagerException
@@ -84,7 +82,7 @@ class RepositoryManagerClientUtil
    * @param credentialsId the id of the credentials configured in jenkisn
    * @return a {@link RepositoryManagerV3Client}
    */
-  static RepositoryManagerV3Client nexus3Client(String url, @Nullable String credentialsId)
+  static RepositoryManagerV3Client nexus3Client(String url, String credentialsId)
       throws URISyntaxException
   {
     def uri = new URI(url)


### PR DESCRIPTION
https://issues.sonatype.org/browse/INT-2878
https://jenkins.ci.sonatype.dev/job/integrations/job/jenkins/job/nexus-platform-plugin-feature/job/INT-2878-remove-jsr305/build?delay=0sec

Notes
* Once nexus-java-api 3.16 is released we won't need the exclusion there
* The parent drags some in so some overrides are added (without a version) to do the exclusion