### PR TITLE
DRAFT: Added flag to enable per job debug logging INT-1076 INT-3615

### DIFF
--- a/src/main/java/org/sonatype/nexus/ci/config/ComToOrgMigrator.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/config/ComToOrgMigrator.groovy
@@ -89,7 +89,8 @@ class ComToOrgMigrator
         'com_sonatype_nexus_ci_iq_IqPolicyEvaluator__iqApplication'          : 'iqApplication',
         'com_sonatype_nexus_ci_iq_IqPolicyEvaluator__iqScanPatterns'         : 'iqScanPatterns',
         'com_sonatype_nexus_ci_iq_IqPolicyEvaluator__failBuildOnNetworkError': 'failBuildOnNetworkError',
-        'com_sonatype_nexus_ci_iq_IqPolicyEvaluator__jobCredentialsId'       : 'jobCredentialsId'
+        'com_sonatype_nexus_ci_iq_IqPolicyEvaluator__jobCredentialsId'       : 'jobCredentialsId',
+        'com_sonatype_nexus_ci_iq_IqPolicyEvaluator__enableDebugLogging'     : 'enableDebugLogging'
     ]
 
     iqPolicyEvaluatorTraitFieldMappings.each { key, value ->

--- a/src/main/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluator.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluator.groovy
@@ -26,5 +26,7 @@ interface IqPolicyEvaluator
 
   String getJobCredentialsId()
 
+  Boolean getEnableDebugLogging()
+
   String getAdvancedProperties()
 }

--- a/src/main/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorBuildStep.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorBuildStep.groovy
@@ -47,6 +47,8 @@ class IqPolicyEvaluatorBuildStep
 
   String jobCredentialsId
 
+  Boolean enableDebugLogging
+
   String advancedProperties
 
   @DataBoundConstructor
@@ -57,6 +59,7 @@ class IqPolicyEvaluatorBuildStep
                              final List<ModuleExclude> iqModuleExcludes,
                              final Boolean failBuildOnNetworkError,
                              final String jobCredentialsId,
+                             final Boolean enableDebugLogging,
                              final String advancedProperties)
   {
     this.jobCredentialsId = jobCredentialsId
@@ -66,6 +69,7 @@ class IqPolicyEvaluatorBuildStep
     this.iqStage = iqStage
     this.iqApplication = iqApplication
     this.advancedProperties = advancedProperties
+    this.enableDebugLogging = enableDebugLogging
   }
 
   @Override
@@ -121,6 +125,11 @@ class IqPolicyEvaluatorBuildStep
 
     @Override
     FormValidation doCheckFailBuildOnNetworkError(@QueryParameter String value) {
+      FormValidation.validateRequired(value)
+    }
+
+    @Override
+    FormValidation doCheckEnableDebugLogging(@QueryParameter String value) {
       FormValidation.validateRequired(value)
     }
 

--- a/src/main/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorDescriptor.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorDescriptor.groovy
@@ -32,5 +32,7 @@ interface IqPolicyEvaluatorDescriptor
 
   ListBoxModel doFillJobCredentialsIdItems(Job job)
 
+  FormValidation doCheckEnableDebugLogging(String value)
+
   FormValidation doVerifyCredentials(String jobCredentialsId, Job job)
 }

--- a/src/main/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorUtil.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorUtil.groovy
@@ -45,12 +45,15 @@ class IqPolicyEvaluatorUtil
     ensureInNodeContext(run, workspace, launcher, listener)
 
     try {
+      LoggerBridge loggerBridge = new LoggerBridge(listener)
+      if (iqPolicyEvaluator.getEnableDebugLogging()) {
+        loggerBridge.setDebugEnabled(true)
+      }
       String applicationId = envVars.expand(iqPolicyEvaluator.getIqApplication()?.applicationId)
       String iqStage = iqPolicyEvaluator.iqStage
 
       checkArgument(iqStage && applicationId, 'Arguments iqApplication and iqStage are mandatory')
 
-      LoggerBridge loggerBridge = new LoggerBridge(listener)
       loggerBridge.debug(Messages.IqPolicyEvaluation_Evaluating())
 
       def iqClient = IqClientFactory.getIqClient(

--- a/src/main/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorWorkflowStep.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorWorkflowStep.groovy
@@ -44,6 +44,8 @@ class IqPolicyEvaluatorWorkflowStep
 
   String jobCredentialsId
 
+  Boolean enableDebugLogging
+
   String advancedProperties
 
   @DataBoundSetter
@@ -64,6 +66,11 @@ class IqPolicyEvaluatorWorkflowStep
   @DataBoundSetter
   public void setJobCredentialsId(final String jobCredentialsId) {
     this.jobCredentialsId = jobCredentialsId
+  }
+
+  @DataBoundSetter
+  public void setEnableDebugLogging(final boolean enableDebugLogging) {
+    this.enableDebugLogging = enableDebugLogging
   }
 
   @DataBoundSetter
@@ -147,6 +154,11 @@ class IqPolicyEvaluatorWorkflowStep
     ListBoxModel doFillJobCredentialsIdItems(@AncestorInPath final Job job) {
       FormUtil.newCredentialsItemsListBoxModel(NxiqConfiguration.serverUrl.toString(), NxiqConfiguration.credentialsId,
           job)
+    }
+
+    @Override
+    FormValidation doCheckEnableDebugLogging(@QueryParameter final String value) {
+      FormValidation.validateRequired(value)
     }
 
     @Override

--- a/src/main/java/org/sonatype/nexus/ci/util/LoggerBridge.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/util/LoggerBridge.groovy
@@ -22,7 +22,7 @@ import org.slf4j.helpers.MessageFormatter
 final class LoggerBridge
     extends MarkerIgnoringBase
 {
-  private static final boolean DEBUG = Boolean.valueOf(System.getProperty(LoggerBridge.getName() + '.debug'))
+  private boolean debugEnabled = Boolean.valueOf(System.getProperty(LoggerBridge.getName() + '.debug'))
 
   private static final String TRACE_PREFIX = '[TRACE]'
 
@@ -52,12 +52,16 @@ final class LoggerBridge
 
   @Override
    boolean isTraceEnabled() {
-    return DEBUG
+    return debugEnabled
   }
 
   @Override
    boolean isDebugEnabled() {
-    return DEBUG
+    return debugEnabled
+  }
+
+  public void setDebugEnabled(boolean debugEnabled) {
+    this.debugEnabled = debugEnabled
   }
 
   @Override
@@ -77,70 +81,70 @@ final class LoggerBridge
 
   @Override
    void trace(final String msg) {
-    if (DEBUG) {
+    if (debugEnabled) {
       log(TRACE_PREFIX, msg, null)
     }
   }
 
   @Override
    void trace(final String format, final Object arg) {
-    if (DEBUG) {
+    if (debugEnabled) {
       log(TRACE_PREFIX, MessageFormatter.format(format, arg))
     }
   }
 
   @Override
    void trace(final String format, final Object arg1, final Object arg2) {
-    if (DEBUG) {
+    if (debugEnabled) {
       log(TRACE_PREFIX, MessageFormatter.format(format, arg1, arg2))
     }
   }
 
   @Override
    void trace(final String format, final Object[] argArray) {
-    if (DEBUG) {
+    if (debugEnabled) {
       log(TRACE_PREFIX, MessageFormatter.arrayFormat(format, argArray))
     }
   }
 
   @Override
    void trace(final String msg, final Throwable t) {
-    if (DEBUG) {
+    if (debugEnabled) {
       log(TRACE_PREFIX, msg, t)
     }
   }
 
   @Override
    void debug(final String msg) {
-    if (DEBUG) {
+    if (debugEnabled) {
       log(DEBUG_PREFIX, msg, null)
     }
   }
 
   @Override
    void debug(final String format, final Object arg) {
-    if (DEBUG) {
+    if (debugEnabled) {
       log(DEBUG_PREFIX, MessageFormatter.format(format, arg))
     }
   }
 
   @Override
    void debug(final String format, final Object arg1, final Object arg2) {
-    if (DEBUG) {
+    if (debugEnabled) {
       log(DEBUG_PREFIX, MessageFormatter.format(format, arg1, arg2))
     }
   }
 
   @Override
    void debug(final String format, final Object[] argArray) {
-    if (DEBUG) {
+    if (debugEnabled) {
       log(DEBUG_PREFIX, MessageFormatter.arrayFormat(format, argArray))
     }
   }
 
   @Override
    void debug(final String msg, final Throwable t) {
-    if (DEBUG) {
+    if (debugEnabled) {
       log(DEBUG_PREFIX, msg, t)
     }
   }

--- a/src/main/resources/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorBuildStep/config.groovy
+++ b/src/main/resources/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorBuildStep/config.groovy
@@ -78,6 +78,10 @@ f.section(title: descriptor.displayName) {
       f.entry(title: _(Messages.IqPolicyEvaluation_JobSpecificCredentials()), field: 'jobCredentialsId') {
         c.select(context:app, includeUser:false, expressionAllowed:false)
       }
+      
+      f.entry(title: _(Messages.IqPolicyEvaluation_EnableDebugLogging()), field: 'enableDebugLogging') {
+        f.checkbox()
+      }
 
       f.entry(title: _(Messages.IqPolicyEvaluation_AdvancedProperties()), field: 'advancedProperties') {
         f.textarea()

--- a/src/main/resources/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorWorkflowStep/config.groovy
+++ b/src/main/resources/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorWorkflowStep/config.groovy
@@ -78,6 +78,10 @@ f.section(title: descriptor.displayName) {
       f.entry(title: _(Messages.IqPolicyEvaluation_JobSpecificCredentials()), field: 'jobCredentialsId') {
         c.select(context:app, includeUser:false, expressionAllowed:false)
       }
+      
+      f.entry(title: _(Messages.IqPolicyEvaluation_EnableDebugLogging()), field: 'enableDebugLogging') {
+        f.checkbox()
+      }
 
       f.entry(title: _(Messages.IqPolicyEvaluation_AdvancedProperties()), field: 'advancedProperties') {
         f.textarea()

--- a/src/main/resources/org/sonatype/nexus/ci/iq/Messages.properties
+++ b/src/main/resources/org/sonatype/nexus/ci/iq/Messages.properties
@@ -28,6 +28,7 @@ IqPolicyEvaluation.ScanPatterns=Scan files in workspace. Wildcards allowed e.g: 
 IqPolicyEvaluation.ModuleExcludes=Module excludes in workspace.
 IqPolicyEvaluation.FailOnNetwork=Fail build when unable to communicate with IQ Server
 IqPolicyEvaluation.JobSpecificCredentials=Use job specific credentials
+IqPolicyEvaluation.EnableDebugLogging=Enable debug logging
 IqPolicyEvaluation.AdvancedProperties=Advanced properties
 
 IqPolicyEvaluation.NoIqServersConfigured=No IQ Server configured.

--- a/src/test/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorDescriptorTest.groovy
+++ b/src/test/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorDescriptorTest.groovy
@@ -268,4 +268,26 @@ abstract class IqPolicyEvaluatorDescriptorTest
     then:
       buildStep.jobCredentialsId == 'jobSpecificCredentialsId'
   }
+
+  def 'it validates that flag enableDebugLogging is required'() {
+    setup:
+      def descriptor = getDescriptor()
+
+    when:
+      "validating enableDebugLogging $enableDebugLogging"
+      def validation = descriptor.doCheckEnableDebugLogging(enableDebugLogging)
+
+    then:
+      "it returns $kind with message $message"
+      validation.kind == kind
+      validation.renderHtml() == message
+
+    where:
+      enableDebugLogging | kind       | message
+      ''                      | Kind.ERROR | 'Required'
+      null                    | Kind.ERROR | 'Required'
+      'true'                  | Kind.OK    | '<div/>'
+      'false'                 | Kind.OK    | '<div/>'
+      'other'                 | Kind.OK    | '<div/>'
+  }
 }

--- a/src/test/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorDescriptorTest.groovy
+++ b/src/test/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorDescriptorTest.groovy
@@ -263,7 +263,7 @@ abstract class IqPolicyEvaluatorDescriptorTest
       GroovyMock(NxiqConfiguration, global: true)
 
     when:
-      def buildStep = new IqPolicyEvaluatorBuildStep(null, null, null, null, null, 'jobSpecificCredentialsId', null)
+      def buildStep = new IqPolicyEvaluatorBuildStep(null, null, null, null, null, 'jobSpecificCredentialsId', null, null)
 
     then:
       buildStep.jobCredentialsId == 'jobSpecificCredentialsId'

--- a/src/test/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorIntegrationTest.groovy
+++ b/src/test/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorIntegrationTest.groovy
@@ -219,7 +219,8 @@ class IqPolicyEvaluatorIntegrationTest
     given: 'a jenkins project'
       FreeStyleProject project = jenkins.createFreeStyleProject()
       project.buildersList.
-          add(new IqPolicyEvaluatorBuildStep('stage', new SelectedApplication('app'), [], [], false, 'cred-id', null))
+          add(new IqPolicyEvaluatorBuildStep('stage', new SelectedApplication('app'), [], [], false, 'cred-id', null,
+            null))
       configureJenkins()
 
     when: 'the build is scheduled'
@@ -295,7 +296,7 @@ class IqPolicyEvaluatorIntegrationTest
       FreeStyleProject project = jenkins.createFreeStyleProject()
       project.buildersList.
           add(new IqPolicyEvaluatorBuildStep('stage', new SelectedApplication('app'), [], [], failBuildOnNetworkError,
-              'cred-id', null))
+              'cred-id', null, null))
       configureJenkins()
 
     when: 'the build is scheduled'
@@ -316,7 +317,7 @@ class IqPolicyEvaluatorIntegrationTest
     given: 'a jenkins project'
       FreeStyleProject project = jenkins.createFreeStyleProject()
       project.buildersList.
-          add(new IqPolicyEvaluatorBuildStep('stage', new SelectedApplication('app'), [], [], true, 'cred-id', null))
+          add(new IqPolicyEvaluatorBuildStep('stage', new SelectedApplication('app'), [], [], true, 'cred-id', null, null))
       configureJenkins()
 
     when: 'the build is scheduled'
@@ -366,7 +367,7 @@ class IqPolicyEvaluatorIntegrationTest
       FreeStyleProject project = jenkins.createFreeStyleProject()
       project.buildersList.
           add(new IqPolicyEvaluatorBuildStep('stage', new SelectedApplication('app'), [], [], failBuildOnNetworkError,
-              'cred-id', null))
+              'cred-id', null, null))
       configureJenkins()
 
     when: 'the build is scheduled'
@@ -461,7 +462,7 @@ class IqPolicyEvaluatorIntegrationTest
       FreeStyleProject project = jenkins.createFreeStyleProject()
       project.buildersList.
           add(new IqPolicyEvaluatorBuildStep('stage', new SelectedApplication('app'), [], [], failBuildOnNetworkError,
-              'cred-id', null))
+              'cred-id', null, null))
       configureJenkins()
 
     when: 'the build is scheduled'
@@ -513,7 +514,7 @@ class IqPolicyEvaluatorIntegrationTest
       FreeStyleProject project = jenkins.createFreeStyleProject()
       project.buildersList.
           add(new IqPolicyEvaluatorBuildStep('stage', new SelectedApplication('app'), [], [], failBuildOnNetworkError,
-              'cred-id', null))
+              'cred-id', null, null))
       configureJenkins()
 
     when: 'the build is scheduled'
@@ -532,7 +533,7 @@ class IqPolicyEvaluatorIntegrationTest
       FreeStyleProject project = jenkins.createFreeStyleProject()
       project.buildersList.
           add(new IqPolicyEvaluatorBuildStep('stage', new SelectedApplication('app'), [], [], failBuildOnNetworkError,
-              'cred-id', null))
+              'cred-id', null, null))
       configureJenkins()
 
     when: 'the build is scheduled'
@@ -598,7 +599,8 @@ class IqPolicyEvaluatorIntegrationTest
     given: 'a jenkins project'
       FreeStyleProject project = jenkins.createFreeStyleProject()
       project.buildersList.
-          add(new IqPolicyEvaluatorBuildStep('stage', new ManualApplication('app'), [], [], false, 'cred-id', null))
+          add(new IqPolicyEvaluatorBuildStep('stage', new ManualApplication('app'), [], [], false, 'cred-id', null,
+            null))
       configureJenkins()
 
     when: 'the build is scheduled'
@@ -623,7 +625,8 @@ class IqPolicyEvaluatorIntegrationTest
 
       FreeStyleProject project = jenkins.createFreeStyleProject()
       project.buildersList.
-          add(new IqPolicyEvaluatorBuildStep('stage', new ManualApplication('$APP'), [], [], false, 'cred-id', null))
+          add(new IqPolicyEvaluatorBuildStep('stage', new ManualApplication('$APP'), [], [], false, 'cred-id', null,
+            null))
       configureJenkins()
 
     when: 'the build is scheduled'
@@ -643,7 +646,8 @@ class IqPolicyEvaluatorIntegrationTest
     given: 'a jenkins project'
       FreeStyleProject project = jenkins.createFreeStyleProject()
       project.buildersList.
-          add(new IqPolicyEvaluatorBuildStep('stage', new SelectedApplication('app'), [], [], false, 'cred-id', null))
+          add(new IqPolicyEvaluatorBuildStep('stage', new SelectedApplication('app'), [], [], false, 'cred-id', null,
+            null))
       configureJenkins()
       def url = 'http://a.com/b/c'
       def prop = new EnvironmentVariablesNodeProperty()
@@ -671,7 +675,8 @@ class IqPolicyEvaluatorIntegrationTest
       def path = getClass().getResource('sampleRepoWithRemoteUrl.zip')
       project.setScm(new ExtractResourceSCM(path))
       project.buildersList
-          .add(new IqPolicyEvaluatorBuildStep('stage', new SelectedApplication('app'), [], [], false, 'cred-id', null))
+          .add(new IqPolicyEvaluatorBuildStep('stage', new SelectedApplication('app'), [], [], false, 'cred-id', null,
+            null))
       configureJenkins()
 
     when: 'the build is scheduled'
@@ -692,7 +697,8 @@ class IqPolicyEvaluatorIntegrationTest
     given: 'a jenkins project'
       FreeStyleProject project = jenkins.createFreeStyleProject()
       project.buildersList
-          .add(new IqPolicyEvaluatorBuildStep('stage', new SelectedApplication('app'), [], [], false, 'cred-id', null))
+          .add(new IqPolicyEvaluatorBuildStep('stage', new SelectedApplication('app'), [], [], false, 'cred-id', null,
+            null))
       configureJenkins()
 
     when: 'the build is scheduled'

--- a/src/test/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorIntegrationTest.groovy
+++ b/src/test/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorIntegrationTest.groovy
@@ -819,6 +819,100 @@ class IqPolicyEvaluatorIntegrationTest
       }
       jenkins.assertBuildStatusSuccess(build)
   }
+  
+  def 'Pipeline build should log debug messages when debug logging is enabled'() {
+    given: 'a jenkins project'
+      WorkflowJob project = jenkins.createProject(WorkflowJob)
+      configureJenkins()
+
+    when: 'the nexus policy evaluator is executed'
+      project.definition = new CpsFlowDefinition('node {\n' +
+          'writeFile file: \'dummy.txt\', text: \'dummy\'\n' +
+          'def result = nexusPolicyEvaluation failBuildOnNetworkError: false, iqApplication: \'app\', ' +
+          'iqStage: \'stage\', enableDebugLogging: true' +
+          '}\n')
+      def build = project.scheduleBuild2(0).get()
+
+    then: 'the application is scanned and evaluated'
+      1 * iqClient.verifyOrCreateApplication(*_) >> true
+      1 * iqClient.scan(*_) >> new ScanResult(new Scan(), File.createTempFile('dummy-scan', '.xml.gz'))
+      1 * iqClient.evaluateApplication(*_) >> new ApplicationPolicyEvaluation(0, 1, 2, 3, 11, 12, 13, 0, [],
+          'http://server/link/to/report')
+
+    then: 'DEBUG messages are logged'
+      jenkins.assertBuildStatusSuccess(build)
+      build.getLog(100).stream().anyMatch({logLine -> logLine.contains('[DEBUG]')})
+  }
+  
+  def 'Pipeline build should not log debug messages when debug logging is not enabled'() {
+    given: 'a jenkins project'
+      WorkflowJob project = jenkins.createProject(WorkflowJob)
+      configureJenkins()
+
+    when: 'the nexus policy evaluator is executed'
+      project.definition = new CpsFlowDefinition('node {\n' +
+          'writeFile file: \'dummy.txt\', text: \'dummy\'\n' +
+          'def result = nexusPolicyEvaluation failBuildOnNetworkError: false, iqApplication: \'app\', ' +
+          'iqStage: \'stage\'' +
+          '}\n')
+      def build = project.scheduleBuild2(0).get()
+
+    then: 'the application is scanned and evaluated'
+      1 * iqClient.verifyOrCreateApplication(*_) >> true
+      1 * iqClient.scan(*_) >> new ScanResult(new Scan(), File.createTempFile('dummy-scan', '.xml.gz'))
+      1 * iqClient.evaluateApplication(*_) >> new ApplicationPolicyEvaluation(0, 1, 2, 3, 11, 12, 13, 0, [],
+          'http://server/link/to/report')
+
+    then: 'DEBUG messages are not logged'
+      jenkins.assertBuildStatusSuccess(build)
+      !build.getLog(100).stream().anyMatch({logLine -> logLine.contains('[DEBUG]')})
+  }
+  
+  def 'Freestyle build should log debug messages when debug logging is enabled'() {
+    given: 'a jenkins project'
+      FreeStyleProject project = jenkins.createFreeStyleProject()
+      Boolean enableDebugLogging = true
+      project.buildersList.
+          add(new IqPolicyEvaluatorBuildStep('stage', new SelectedApplication('app'), [], [], false, 'cred-id',
+            enableDebugLogging, null))
+      configureJenkins()
+
+    when: 'the build is scheduled'
+      def build = project.scheduleBuild2(0).get()
+
+    then: 'the application is scanned and evaluated'
+      1 * iqClient.verifyOrCreateApplication(*_) >> true
+      1 * iqClient.scan(*_) >> new ScanResult(new Scan(), File.createTempFile('dummy-scan', '.xml.gz'))
+      1 * iqClient.evaluateApplication(*_) >> new ApplicationPolicyEvaluation(0, 1, 2, 3, 11, 12, 13, 0, [],
+          'http://server/link/to/report')
+
+    then: 'DEBUG messages are logged'
+      jenkins.assertBuildStatusSuccess(build)
+      build.getLog(100).stream().anyMatch({logLine -> logLine.contains('[DEBUG]')})
+  }
+  
+  def 'Freestyle build should not log debug messages when debug logging is not enabled'() {
+    given: 'a jenkins project'
+      FreeStyleProject project = jenkins.createFreeStyleProject()
+      Boolean enableDebugLogging = false
+      project.buildersList.
+          add(new IqPolicyEvaluatorBuildStep('stage', new SelectedApplication('app'), [], [], false, 'cred-id',
+            enableDebugLogging, null))
+      configureJenkins()
+
+    when: 'the build is scheduled'
+      def build = project.scheduleBuild2(0).get()
+
+    then: 'the application is scanned and evaluated'
+      1 * iqClient.verifyOrCreateApplication(*_) >> true
+      1 * iqClient.scan(*_) >> new ScanResult(new Scan(), File.createTempFile('dummy-scan', '.xml.gz'))
+      1 * iqClient.evaluateApplication(*_) >> new ApplicationPolicyEvaluation(0, 1, 2, 3, 11, 12, 13, 0, [],
+          'http://server/link/to/report')
+
+    then: 'DEBUG messages are logged'
+      jenkins.assertBuildStatusSuccess(build)
+      !build.getLog(100).stream().anyMatch({logLine -> logLine.contains('[DEBUG]')})
+  }
 
   def configureJenkins() {
     nxiqConfiguration = [new NxiqConfiguration('http://server/url', 'cred-id')]

--- a/src/test/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorSlaveIntegrationTest.groovy
+++ b/src/test/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorSlaveIntegrationTest.groovy
@@ -122,7 +122,8 @@ class IqPolicyEvaluatorSlaveIntegrationTest
       FreeStyleProject project = jenkins.createFreeStyleProject()
       project.assignedNode = jenkins.createSlave()
       project.buildersList.
-          add(new IqPolicyEvaluatorBuildStep('stage', new SelectedApplication('app'), [], [], false, 'cred-id', null))
+          add(new IqPolicyEvaluatorBuildStep('stage', new SelectedApplication('app'), [], [], false, 'cred-id', null,
+            null))
       configureJenkins()
 
     and: 'a mock IQ server stub'
@@ -140,7 +141,8 @@ class IqPolicyEvaluatorSlaveIntegrationTest
       FreeStyleProject project = jenkins.createFreeStyleProject()
       project.assignedNode = jenkins.createSlave()
       project.buildersList.
-          add(new IqPolicyEvaluatorBuildStep('stage', new SelectedApplication('app'), [], [], false, 'cred-id', null))
+          add(new IqPolicyEvaluatorBuildStep('stage', new SelectedApplication('app'), [], [], false, 'cred-id', null,
+            null))
       configureJenkins()
 
     and: 'a mock IQ server stub'
@@ -158,7 +160,8 @@ class IqPolicyEvaluatorSlaveIntegrationTest
       FreeStyleProject project = jenkins.createFreeStyleProject()
       project.assignedNode = jenkins.createSlave()
       project.buildersList.
-          add(new IqPolicyEvaluatorBuildStep('stage', new SelectedApplication('app'), [], [], false, 'cred-id', null))
+          add(new IqPolicyEvaluatorBuildStep('stage', new SelectedApplication('app'), [], [], false, 'cred-id', null,
+            null))
       configureJenkins()
 
     and: 'a mock IQ server stub'
@@ -241,7 +244,8 @@ class IqPolicyEvaluatorSlaveIntegrationTest
       FreeStyleProject project = jenkins.createFreeStyleProject()
       project.assignedNode = jenkins.createSlave()
       project.buildersList.
-          add(new IqPolicyEvaluatorBuildStep('stage', new SelectedApplication('app'), [], [], false, 'cred-id', null))
+          add(new IqPolicyEvaluatorBuildStep('stage', new SelectedApplication('app'), [], [], false, 'cred-id', null,
+            null))
       configureJenkins()
 
     and: 'a mock IQ server stub'
@@ -264,7 +268,8 @@ class IqPolicyEvaluatorSlaveIntegrationTest
       def path = getClass().getResource('sampleRepoWithRemoteUrl.zip')
       project.setScm(new ExtractResourceSCM(path))
       project.buildersList
-          .add(new IqPolicyEvaluatorBuildStep('stage', new SelectedApplication('app'), [], [], false, 'cred-id', null))
+          .add(new IqPolicyEvaluatorBuildStep('stage', new SelectedApplication('app'), [], [], false, 'cred-id', null,
+            null))
       configureJenkins()
 
     and: 'a mock IQ server stub'

--- a/src/test/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorTest.groovy
+++ b/src/test/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorTest.groovy
@@ -97,7 +97,7 @@ class IqPolicyEvaluatorTest
   def 'it retrieves proprietary config followed by remote scan followed by evaluation in correct order (happy path)'() {
     setup:
       def buildStep = new IqPolicyEvaluatorBuildStep("stage", new SelectedApplication('appId'), [new ScanPattern("*.jar")], [],
-          false, null, null)
+          false, null, null, null)
       def evaluationResult = new ApplicationPolicyEvaluation(0, 0, 0, 0, 0, 0, 0, 0, emptyList(), reportUrl)
       def remoteScanner = Mock(RemoteScanner)
 
@@ -122,7 +122,7 @@ class IqPolicyEvaluatorTest
       def remoteScanner = Mock(RemoteScanner)
       def buildStep = new IqPolicyEvaluatorBuildStep("stage", new SelectedApplication('appId'),
           [new ScanPattern('/path1/$SCAN_PATTERN/path2/')],
-          [], false, "131-cred", null)
+          [], false, "131-cred", null, null)
 
     when:
       buildStep.perform(run, launcher, Mock(BuildListener))
@@ -138,7 +138,7 @@ class IqPolicyEvaluatorTest
     setup:
       def remoteScanner = Mock(RemoteScanner)
       def buildStep = new IqPolicyEvaluatorBuildStep("stage", new SelectedApplication('appId'),
-          [new ScanPattern('/path1/$NONEXISTENT_SCAN_PATTERN/path2/')], [], false, '131-cred', null)
+          [new ScanPattern('/path1/$NONEXISTENT_SCAN_PATTERN/path2/')], [], false, '131-cred', null, null)
 
     when:
       buildStep.perform(run, launcher, Mock(BuildListener))
@@ -154,7 +154,7 @@ class IqPolicyEvaluatorTest
     setup:
       def remoteScanner = Mock(RemoteScanner)
       def buildStep = new IqPolicyEvaluatorBuildStep("stage", new SelectedApplication('appId'), [],
-          [new ModuleExclude('/path1/$NONEXISTENT_MODULE_EXCLUDE/path2/')], false, "131-cred", null)
+          [new ModuleExclude('/path1/$NONEXISTENT_MODULE_EXCLUDE/path2/')], false, "131-cred", null, null)
 
     when:
       buildStep.perform(run, launcher, Mock(BuildListener))
@@ -171,7 +171,7 @@ class IqPolicyEvaluatorTest
     setup:
       def remoteScanner = Mock(RemoteScanner)
       def buildStep = new IqPolicyEvaluatorBuildStep("stage", new SelectedApplication('appId'), [],
-          [new ModuleExclude('/path1/$MODULE_EXCLUDE/path2/')], false, "131-cred", null)
+          [new ModuleExclude('/path1/$MODULE_EXCLUDE/path2/')], false, "131-cred", null, null)
 
     when:
       buildStep.perform(run, launcher, Mock(BuildListener))
@@ -188,7 +188,7 @@ class IqPolicyEvaluatorTest
     setup:
       iqClient.getProprietaryConfigForApplicationEvaluation('appId') >> { throw exception }
       def buildStep = new IqPolicyEvaluatorBuildStep('stage', new SelectedApplication('appId'), [new ScanPattern('*.jar')], [],
-          failBuildOnNetworkError, '131-cred', null)
+          failBuildOnNetworkError, '131-cred', null, null)
 
     when:
       buildStep.perform(run, launcher, Mock(BuildListener))
@@ -211,7 +211,7 @@ class IqPolicyEvaluatorTest
     setup:
       iqClient.getProprietaryConfigForApplicationEvaluation('appId') >> { throw exception }
       def buildStep = new IqPolicyEvaluatorBuildStep('stage', new SelectedApplication('appId'), [new ScanPattern('*.jar')], [],
-          failBuildOnNetworkError, '131-cred', null)
+          failBuildOnNetworkError, '131-cred', null, null)
       PrintStream logger = Mock()
       BuildListener listener = Mock() {
         getLogger() >> logger
@@ -236,7 +236,7 @@ class IqPolicyEvaluatorTest
     setup:
       iqClient.getProprietaryConfigForApplicationEvaluation('appId') >> proprietaryConfig
       def buildStep = new IqPolicyEvaluatorBuildStep('stage', new SelectedApplication('appId'), [new ScanPattern('*.jar')], [],
-          false, '131-cred', null)
+          false, '131-cred', null, null)
       RemoteScanner remoteScanner = Mock()
       RemoteScannerFactory.getRemoteScanner(*_) >> remoteScanner
 
@@ -254,7 +254,7 @@ class IqPolicyEvaluatorTest
     setup:
       def failBuildOnNetworkError = false
       def buildStep = new IqPolicyEvaluatorBuildStep('stage', new SelectedApplication('appId'), [new ScanPattern('*.jar')], [],
-          failBuildOnNetworkError, '131-cred', null)
+          failBuildOnNetworkError, '131-cred', null, null)
 
     when:
       buildStep.perform(run, launcher, Mock(BuildListener))
@@ -269,7 +269,7 @@ class IqPolicyEvaluatorTest
   def 'global no credentials are passed to the client builder when no job credentials provided'() {
     setup:
       def buildStep = new IqPolicyEvaluatorBuildStep('stage', new SelectedApplication('appId'), [new ScanPattern('*.jar')], [],
-          true, jobCredentials, null)
+          true, jobCredentials, null, null)
 
     when:
       buildStep.perform(run, launcher, Mock(BuildListener))
@@ -285,7 +285,7 @@ class IqPolicyEvaluatorTest
   def 'evaluation result outcome determines build status'() {
     setup:
       def buildStep = new IqPolicyEvaluatorBuildStep('stage', new SelectedApplication('appId'), [new ScanPattern('*.jar')], [],
-          false, '131-cred', null)
+          false, '131-cred', null, null)
 
     when:
       buildStep.perform(run, launcher, Mock(BuildListener))
@@ -306,7 +306,7 @@ class IqPolicyEvaluatorTest
   def 'evaluation throws exception when build results in failure'() {
     setup:
       def buildStep = new IqPolicyEvaluatorBuildStep('stage', new SelectedApplication('appId'), [new ScanPattern('*.jar')], [],
-          false, '131-cred', null)
+          false, '131-cred', null, null)
       def policyEvaluation = new ApplicationPolicyEvaluation(0, 0, 0, 0, 0, 0, 0, 0,
           [new PolicyAlert(null, [new Action(Action.ID_FAIL)])], reportUrl)
 
@@ -327,7 +327,7 @@ class IqPolicyEvaluatorTest
   def 'prints an error message on failure'() {
     setup:
       def buildStep = new IqPolicyEvaluatorBuildStep('stage', new SelectedApplication('appId'), [new ScanPattern('*.jar')], [],
-          false, '131-cred', null)
+          false, '131-cred', null, null)
       BuildListener listener = Mock()
       PrintStream log = Mock()
       listener.getLogger() >> log
@@ -354,7 +354,7 @@ class IqPolicyEvaluatorTest
   def 'prints a log message on warnings'() {
     setup:
       def buildStep = new IqPolicyEvaluatorBuildStep('stage', new SelectedApplication('appId'), [new ScanPattern('*.jar')], [],
-          false, '131-cred', null)
+          false, '131-cred', null, null)
       BuildListener listener = Mock()
       PrintStream log = Mock()
       listener.getLogger() >> log
@@ -378,7 +378,7 @@ class IqPolicyEvaluatorTest
   def 'prints a summary on success'() {
     setup:
       def buildStep = new IqPolicyEvaluatorBuildStep('stage', new SelectedApplication('appId'), [new ScanPattern('*.jar')], [],
-          false, '131-cred', null)
+          false, '131-cred', null, null)
       BuildListener listener = Mock()
       PrintStream log = Mock()
       listener.getLogger() >> log
@@ -399,7 +399,7 @@ class IqPolicyEvaluatorTest
   def 'prints an error message if not in node context'() {
     setup:
       def buildStep = new IqPolicyEvaluatorBuildStep("stage", new SelectedApplication('appId'),
-          [new ScanPattern("*.jar")], [],false, null, null)
+          [new ScanPattern("*.jar")], [],false, null, null, null)
       def listener = Mock(BuildListener)
 
     when:
@@ -415,7 +415,7 @@ class IqPolicyEvaluatorTest
     setup:
       def buildStep = new IqPolicyEvaluatorBuildStep("stage", new SelectedApplication('appId'),
           [new ScanPattern("*.jar")], [],
-          false, null, null)
+          false, null, null, null)
       def evaluationResult = new ApplicationPolicyEvaluation(0, 0, 0, 0, 0, 0, 0, 0, emptyList(), reportUrl)
       def remoteScanner = Mock(RemoteScanner)
 


### PR DESCRIPTION
This PR adds a flag that allows users to enable debug logging for the nexus jenkins plugin on a per job basis.
For jobs:
![image](https://user-images.githubusercontent.com/239673/96017215-bba32500-0e17-11eb-9c05-142df7b5d606.png)
For pipelines:
![image](https://user-images.githubusercontent.com/239673/96017375-eee5b400-0e17-11eb-8576-03d003b2bd07.png)

https://issues.sonatype.org/browse/INT-3615
https://jenkins.ci.sonatype.dev/job/integrations/job/jenkins/job/nexus-platform-plugin-feature/job/INT-3615_DebugLoggingFlag/lastBuild/

I'll add tests if this solution is accepted.