### PR TITLE
Add support for running the test with Java11 in CI builds INT-1918 INT-4033

### DIFF
--- a/Jenkinsfile.sonatype
+++ b/Jenkinsfile.sonatype
@@ -69,6 +69,8 @@ if (!params.isRelease) {
   }
 
   mavenSnapshotPipeline(
+      mavenOptions: '-D skipTests',
+      downstreamJobName: 'extra-tests',
       notificationSender: postHandler,
       iqPolicyEvaluation: iqPolicyEvaluation,
       runFeatureBranchPolicyEvaluations: true

--- a/Jenkinsfile.sonatype.extra-tests
+++ b/Jenkinsfile.sonatype.extra-tests
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2011-present Sonatype, Inc. All rights reserved.
+ * Includes the third-party code listed at http://links.sonatype.com/products/clm/attributions.
+ * "Sonatype" is a trademark of Sonatype, Inc.
+ */
+@Library(['private-pipeline-library', 'jenkins-shared', 'int-jenkins-shared']) _
+
+String agentLabel = 'ubuntu-zion'
+
+def runTests(String javaVersion = 'Java 8') {
+  def config = mavenCommon(
+      javaVersion: javaVersion,
+      mavenVersion: 'Maven 3.2.x',
+      useEventSpy: false
+  )
+  mvn config, 'clean install'
+}
+
+def captureResultsAndCleanup() {
+  archiveArtifacts(artifacts: '**/target/*-reports/**')
+  collectTestResults(['**/target/*-reports/*.xml'])
+  deleteDir()
+}
+
+pipeline {
+  agent none
+  options {
+    buildDiscarder(
+        logRotator(numToKeepStr: '100', daysToKeepStr: '14', artifactNumToKeepStr: '20', artifactDaysToKeepStr: '10')
+    )
+    timestamps()
+  }
+  stages {
+    stage('Parallel Test Groups') {
+      parallel {
+        stage('Unit and Integration Tests - Java8') {
+          agent { label agentLabel }
+          steps {
+            runTests('Java 8')
+          }
+          post {
+            always {
+              captureResultsAndCleanup()
+            }
+          }
+        }
+        stage('Unit and Integration Tests - Java11') {
+          agent { label agentLabel }
+          steps {
+            runTests('OpenJDK 11')
+          }
+          post {
+            always {
+              captureResultsAndCleanup()
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
https://issues.sonatype.org/browse/INT-4033
https://jenkins.ci.sonatype.dev/job/integrations/job/jenkins/job/feature-snapshots/job/INT-1918_SupportJava11/lastBuild/

I've also added a new Jenkins job to build feature branches:
https://jenkins.ci.sonatype.dev/job/integrations/job/jenkins/job/feature-snapshots/
which uses a new Jenkins job to run the tests with various Java versions:
https://jenkins.ci.sonatype.dev/job/integrations/job/jenkins/job/extra-tests/