### PR TITLE
Add support for running the tests with Java 14 in CI builds INT-1918 INT-4078

### DIFF
--- a/Jenkinsfile.sonatype.extra-tests
+++ b/Jenkinsfile.sonatype.extra-tests
@@ -55,6 +55,17 @@ pipeline {
             }
           }
         }
+        stage('Unit and Integration Tests - Java14') {
+          agent { label agentLabel }
+          steps {
+            runTests('OpenJDK 14')
+          }
+          post {
+            always {
+              captureResultsAndCleanup()
+            }
+          }
+        }
       }
     }
   }

--- a/pom.xml
+++ b/pom.xml
@@ -153,9 +153,16 @@
       </dependency>
 
       <dependency>
-        <groupId>cglib</groupId>
-        <artifactId>cglib-nodep</artifactId>
-        <version>3.3.0</version>
+        <groupId>net.bytebuddy</groupId>
+        <artifactId>byte-buddy</artifactId>
+        <version>1.10.18</version>
+        <scope>test</scope>
+        <exclusions>
+          <exclusion>
+            <artifactId>junit-dep</artifactId>
+            <groupId>*</groupId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <dependency>
@@ -258,11 +265,11 @@
     </dependency>
 
     <dependency>
-      <groupId>cglib</groupId>
-      <artifactId>cglib-nodep</artifactId>
+      <groupId>net.bytebuddy</groupId>
+      <artifactId>byte-buddy</artifactId>
       <scope>test</scope>
     </dependency>
-
+    
     <dependency>
       <groupId>org.objenesis</groupId>
       <artifactId>objenesis</artifactId>


### PR DESCRIPTION
https://issues.sonatype.org/browse/INT-4078
https://jenkins.ci.sonatype.dev/job/integrations/job/jenkins/job/feature-snapshots/job/INT-4078_SupportJava14/lastBuild/

I replaced cglib-nodep:3.3.0 with byte-buddy:1.10.18 because cglib-nodep:3.3.0 (latest version) doesn't support Java 14 (only up to Java 13).