### PR TITLE
Upgrade to java-api:3.26

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -208,7 +208,7 @@
     <dependency>
       <groupId>com.sonatype.nexus</groupId>
       <artifactId>nexus-platform-api</artifactId>
-      <version>3.25</version>
+      <version>3.26</version>
       <classifier>internal</classifier>
     </dependency>
 


### PR DESCRIPTION
Jira: https://issues.sonatype.org/browse/CLM-17707

The fix for the above ticket seems to have been fixed with https://github.com/sonatype/nexus-java-api/pull/151. This is available with java-api 3:26 and I'd like get Jenkins plugin upgraded to this version for testing. 
