### PR TITLE
INT-3589 Decouple IqClientFactory from NxiqConfiguration

### DIFF
--- a/src/main/java/org/sonatype/nexus/ci/iq/IqClientFactory.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/iq/IqClientFactory.groovy
@@ -19,7 +19,6 @@ import com.sonatype.nexus.api.common.ServerConfig
 import com.sonatype.nexus.api.iq.internal.InternalIqClient
 import com.sonatype.nexus.api.iq.internal.InternalIqClientBuilder
 
-import org.sonatype.nexus.ci.config.NxiqConfiguration
 import org.sonatype.nexus.ci.util.ProxyUtil
 
 import com.cloudbees.plugins.credentials.CredentialsMatchers
@@ -38,9 +37,9 @@ import static com.google.common.base.Preconditions.checkNotNull
 class IqClientFactory
 {
   static InternalIqClient getIqClient(IqClientFactoryConfiguration conf = new IqClientFactoryConfiguration()) {
-    def serverUrl = conf.serverUrl ?: NxiqConfiguration.serverUrl
-    def context = conf.context ?: Jenkins.instance
-    def credentialsId = conf.credentialsId ?: NxiqConfiguration.credentialsId
+    def serverUrl = checkNotNull(conf.serverUrl, "Server URL is required.")
+    def credentialsId = checkNotNull(conf.credentialsId, "A Jenkins credentials id is required.")
+    def context = checkNotNull(conf.context ?: Jenkins.instance, "Unable to determine Jenkins context.")
     def credentials = findCredentials(serverUrl, credentialsId, context)
     def serverConfig = getServerConfig(serverUrl, credentials)
     def proxyConfig = getProxyConfig(serverUrl)

--- a/src/main/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorUtil.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorUtil.groovy
@@ -58,8 +58,9 @@ class IqPolicyEvaluatorUtil
       loggerBridge.debug(Messages.IqPolicyEvaluation_Evaluating())
 
       def iqClient = IqClientFactory.getIqClient(
-          new IqClientFactoryConfiguration(credentialsId: iqPolicyEvaluator.jobCredentialsId, context: run.parent,
-              log: loggerBridge))
+        new IqClientFactoryConfiguration(
+          credentialsId: iqPolicyEvaluator.jobCredentialsId ?: NxiqConfiguration.getCredentialsId(),
+          serverUrl: NxiqConfiguration.getServerUrl(), context: run.parent, log: loggerBridge))
 
       iqClient.validateServerVersion(MINIMAL_SERVER_VERSION_REQUIRED)
       def verified = iqClient.verifyOrCreateApplication(applicationId)

--- a/src/main/java/org/sonatype/nexus/ci/util/IqUtil.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/util/IqUtil.groovy
@@ -43,7 +43,9 @@ class IqUtil
   static ListBoxModel doFillIqStageItems(final String credentialsId, final Job job) {
     if (NxiqConfiguration.iqConfig) {
       def client = IqClientFactory.
-          getIqClient(new IqClientFactoryConfiguration(credentialsId: credentialsId, context: job))
+        getIqClient(
+          new IqClientFactoryConfiguration(credentialsId: credentialsId, serverUrl: NxiqConfiguration.getServerUrl(),
+            context: job))
       FormUtil.newListBoxModel({ it.name }, { it.id }, client.getLicensedStages(Context.CI))
     }
     else {
@@ -54,7 +56,9 @@ class IqUtil
   static ListBoxModel doFillIqApplicationItems(final String credentialsId, final Job job) {
     if (NxiqConfiguration.iqConfig) {
       def client = IqClientFactory.
-          getIqClient(new IqClientFactoryConfiguration(credentialsId: credentialsId, context: job))
+        getIqClient(
+          new IqClientFactoryConfiguration(credentialsId: credentialsId, serverUrl: NxiqConfiguration.getServerUrl(),
+            context: job))
       FormUtil.newListBoxModel({ it.name }, { it.publicId }, client.getApplicationsForApplicationEvaluation())
     }
     else {

--- a/src/test/java/org/sonatype/nexus/ci/iq/IqClientFactoryTest.groovy
+++ b/src/test/java/org/sonatype/nexus/ci/iq/IqClientFactoryTest.groovy
@@ -65,7 +65,7 @@ class IqClientFactoryTest
       ex.message =~ /No credentials were found for credentials 42/
   }
 
-  def 'it creates a client when credentialsId given'() {
+  def 'it creates a client when serverUrl and credentialsId given'() {
     setup:
       def url = 'http://foo.com'
       def credentialsId = "42"
@@ -110,117 +110,84 @@ class IqClientFactoryTest
       exception.message == 'Credentials of type ' + unsupportedCreds.class.simpleName + ' are not supported'
   }
 
-  def 'it uses configured serverUrl and credentialsId'() {
-    setup:
-      GroovyMock(NxiqConfiguration, global: true)
-      GroovyMock(InternalIqClientBuilder, global: true)
-      def iqClientBuilder = Mock(InternalIqClientBuilder)
-      InternalIqClientBuilder.create() >> iqClientBuilder
-      NxiqConfiguration.serverUrl >> URI.create("https://server/url/")
-      NxiqConfiguration.credentialsId >> "123-cred-456"
+
+  def 'it throws a NullPointerException when credentialsId is not provided'() {
+    given:
+      def url = 'http://foo.com'
+
+    when:
+      IqClientFactory.getIqClient(
+        new IqClientFactoryConfiguration(serverUrl: URI.create(url)))
+    then:
+      NullPointerException exception = thrown()
+      exception.cause == null
+      exception.message == "A Jenkins credentials id is required."
+  }
+
+  def 'it throws a NullPointerException when serverUrl is not provided'() {
+    given:
+      def credentialsId = "42"
       CredentialsMatchers.firstOrNull(_, _) >> credentials
 
     when:
-      IqClientFactory.getIqClient()
+      IqClientFactory.getIqClient(
+        new IqClientFactoryConfiguration(credentialsId: credentialsId))
+    then:
+      NullPointerException exception = thrown()
+      exception.cause == null
+      exception.message == "Server URL is required."
+
+  }
+
+  def 'it uses provided serverUrl and credentialsId'() {
+    given:
+      GroovyMock(InternalIqClientBuilder, global: true)
+      def iqClientBuilder = Mock(InternalIqClientBuilder)
+      InternalIqClientBuilder.create() >> iqClientBuilder
+      CredentialsMatchers.firstOrNull(_, _) >> credentials
+      def uri = URI.create('http://foo.com/')
+      def credentialsId = '123-cred-456'
+
+    when:
+      IqClientFactory.
+        getIqClient(new IqClientFactoryConfiguration(credentialsId: credentialsId, serverUrl: uri))
 
     then:
-      1 * iqClientBuilder.withServerConfig { it.address == URI.create("https://server/url/") } >> iqClientBuilder
+      1 * iqClientBuilder.withServerConfig{ ServerConfig config ->
+        config.address == uri
+      } >> iqClientBuilder
       1 * iqClientBuilder.withProxyConfig(_) >> iqClientBuilder
       iqClientBuilder.withLogger(_) >> iqClientBuilder
 
     and:
-      1 * CredentialsMatchers.withId("123-cred-456")
+      1 * CredentialsMatchers.withId(credentialsId)
   }
 
   def 'it uses job specific credentials when provided'() {
     setup:
-      def globalConfiguration = GlobalNexusConfiguration.globalNexusConfiguration
-      def nxiqConfiguration = new NxiqConfiguration('http://localhost/', 'credentialsId', false)
-      globalConfiguration.iqConfigs = []
-      globalConfiguration.iqConfigs.add(nxiqConfiguration)
-      globalConfiguration.save()
-
-      CredentialsMatchers.firstOrNull(_, _) >> credentials
-
       GroovyMock(InternalIqClientBuilder, global: true)
       def iqClientBuilder = Mock(InternalIqClientBuilder)
       InternalIqClientBuilder.create() >> iqClientBuilder
+      CredentialsMatchers.firstOrNull(_, _) >> credentials
+      def uri = URI.create('http://foo.com/')
 
     when:
       IqClientFactory.getIqClient(
-          new IqClientFactoryConfiguration(credentialsId: 'jobSpecificCredentialsId', context: Mock(Job)))
+        new IqClientFactoryConfiguration(credentialsId: 'jobSpecificCredentialsId', serverUrl: uri, context: Mock(Job)))
+
     then:
       1 * iqClientBuilder.withServerConfig { ServerConfig config ->
-        config.address == URI.create('http://localhost/')
+        config.address == uri
       } >> iqClientBuilder
       1 * iqClientBuilder.withProxyConfig(_) >> iqClientBuilder
       iqClientBuilder.withLogger(_) >> iqClientBuilder
+
+    and:
       1 * CredentialsMatchers.withId('jobSpecificCredentialsId')
-  }
-
-  def 'it interprets an empty String job credentials as not provided'() {
-    setup:
-      def globalConfiguration = GlobalNexusConfiguration.globalNexusConfiguration
-      def nxiqConfiguration = new NxiqConfiguration('http://localhost/', 'credentialsId', false)
-      globalConfiguration.iqConfigs = []
-      globalConfiguration.iqConfigs.add(nxiqConfiguration)
-      globalConfiguration.save()
-
-      CredentialsMatchers.firstOrNull(_, _) >> credentials
-
-      GroovyMock(InternalIqClientBuilder, global: true)
-      def iqClientBuilder = Mock(InternalIqClientBuilder)
-      InternalIqClientBuilder.create() >> iqClientBuilder
-
-    when:
-      IqClientFactory.getIqClient(new IqClientFactoryConfiguration(credentialsId: ''))
-
-    then:
-      1 * iqClientBuilder.withServerConfig { ServerConfig config ->
-        config.address == URI.create('http://localhost/')
-      } >> iqClientBuilder
-      1 * iqClientBuilder.withProxyConfig(_) >> iqClientBuilder
-      iqClientBuilder.withLogger(_) >> iqClientBuilder
-      1 * CredentialsMatchers.withId('credentialsId')
-  }
-
-  def 'it uses job specific credentialsId when provided'() {
-    setup:
-      final String serverUrl = 'http://localhost/'
-      final String credentialsId = '123-cred-456'
-
-      def globalConfiguration = GlobalNexusConfiguration.globalNexusConfiguration
-      def nxiqConfiguration = new NxiqConfiguration(serverUrl, credentialsId, false)
-      globalConfiguration.iqConfigs = []
-      globalConfiguration.iqConfigs.add(nxiqConfiguration)
-      globalConfiguration.save()
-
-      jenkinsRule.instance.proxy = new ProxyConfiguration('http://proxy/url', 9080, null, null, '')
-
-      CredentialsMatchers.firstOrNull(_, _) >> credentials
-
-      GroovyMock(IqClientBuilder, global: true)
-      def iqClientBuilder = Mock(InternalIqClientBuilder)
-      InternalIqClientBuilder.create() >> iqClientBuilder
-
-    when:
-      IqClientFactory.getIqClient(new IqClientFactoryConfiguration(credentialsId: 'job-specific-creds'))
-
-    then:
-      1 * CredentialsMatchers.withId('job-specific-creds')
   }
 
   def 'it uses configured proxy when configured'() {
     setup:
-      final String serverUrl = 'http://localhost/'
-      final String credentialsId = '123-cred-456'
-
-      def globalConfiguration = GlobalNexusConfiguration.globalNexusConfiguration
-      def nxiqConfiguration = new NxiqConfiguration(serverUrl, credentialsId, false)
-      globalConfiguration.iqConfigs = []
-      globalConfiguration.iqConfigs.add(nxiqConfiguration)
-      globalConfiguration.save()
-
       jenkinsRule.instance.proxy = new ProxyConfiguration('localhost', 8888, null, null, '')
 
       CredentialsMatchers.firstOrNull(_, _) >> credentials
@@ -232,6 +199,7 @@ class IqClientFactoryTest
 
     when:
       clientGetter()
+
     then:
       1 * iqClientBuilder.withServerConfig { ServerConfig config ->
         config.address == URI.create(expectedServerUrl)
@@ -244,15 +212,20 @@ class IqClientFactoryTest
 
     where:
       clientGetter << [
-          { -> IqClientFactory.getIqClient(new IqClientFactoryConfiguration()) },
-          { -> IqClientFactory.getIqClient(
-              new IqClientFactoryConfiguration(credentialsId: '123-cred-456', serverUrl: URI.create('http://127.0.0.1/'))) },
-          { -> IqClientFactory.getIqClient(new IqClientFactoryConfiguration(credentialsId: '123-cred-456')) }
+        { ->
+          IqClientFactory.getIqClient(
+            new IqClientFactoryConfiguration(credentialsId: '123-cred-456', serverUrl: URI.create(
+              'http://localhost/')))
+        },
+        { ->
+          IqClientFactory.getIqClient(
+            new IqClientFactoryConfiguration(credentialsId: '123-cred-456', serverUrl: URI.create(
+              'http://127.0.0.1/')))
+        }
       ]
       expectedServerUrl << [
         'http://localhost/',
-        'http://127.0.0.1/',
-        'http://localhost/'
+        'http://127.0.0.1/'
       ]
   }
 
@@ -260,12 +233,6 @@ class IqClientFactoryTest
     setup:
       final String serverUrl = 'http://localhost/'
       final String credentialsId = '123-cred-456'
-
-      def globalConfiguration = GlobalNexusConfiguration.globalNexusConfiguration
-      def nxiqConfiguration = new NxiqConfiguration(serverUrl, credentialsId, false)
-      globalConfiguration.iqConfigs = []
-      globalConfiguration.iqConfigs.add(nxiqConfiguration)
-      globalConfiguration.save()
 
       jenkinsRule.instance.proxy = new ProxyConfiguration('localhost', 8888, 'username', 'password', '')
 
@@ -278,7 +245,9 @@ class IqClientFactoryTest
       iqClientBuilder.withInstanceId(_) >> iqClientBuilder
 
     when:
-      IqClientFactory.getIqClient()
+      IqClientFactory.
+        getIqClient(new IqClientFactoryConfiguration(credentialsId: credentialsId, serverUrl: URI.create(serverUrl)))
+
     then:
       1 * iqClientBuilder.withServerConfig { ServerConfig config ->
         config.address == URI.create(serverUrl)

--- a/src/test/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorIntegrationTest.groovy
+++ b/src/test/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorIntegrationTest.groovy
@@ -14,6 +14,7 @@ package org.sonatype.nexus.ci.iq
 
 
 import com.sonatype.insight.scan.model.Scan
+import com.sonatype.nexus.api.common.ServerConfig
 import com.sonatype.nexus.api.exception.IqClientException
 import com.sonatype.nexus.api.iq.Action
 import com.sonatype.nexus.api.iq.ApplicationPolicyEvaluation
@@ -907,11 +908,83 @@ class IqPolicyEvaluatorIntegrationTest
       1 * iqClient.verifyOrCreateApplication(*_) >> true
       1 * iqClient.scan(*_) >> new ScanResult(new Scan(), File.createTempFile('dummy-scan', '.xml.gz'))
       1 * iqClient.evaluateApplication(*_) >> new ApplicationPolicyEvaluation(0, 1, 2, 3, 11, 12, 13, 0, [],
-          'http://server/link/to/report')
+        'http://server/link/to/report')
 
     then: 'DEBUG messages are logged'
       jenkins.assertBuildStatusSuccess(build)
-      !build.getLog(100).stream().anyMatch({logLine -> logLine.contains('[DEBUG]')})
+      !build.getLog(100).stream().anyMatch({ logLine -> logLine.contains('[DEBUG]') })
+  }
+
+  def 'Declarative pipeline should use provided job credential id'() {
+    given: 'a jenkins project'
+      WorkflowJob project = jenkins.createProject(WorkflowJob)
+      configureJenkins()
+      UsernamePasswordCredentials projectCredentials = new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL,
+        '131-cred', 'project-cred', 'project-user', 'project-password')
+      CredentialsProvider.lookupStores(jenkins.jenkins).first().addCredentials(Domain.global(), projectCredentials)
+
+    when: 'the nexus policy evaluator is executed'
+      project.definition = new CpsFlowDefinition('''
+        pipeline { 
+          agent any 
+          stages { 
+            stage("Example") { 
+              steps { 
+                writeFile file: 'dummy.txt', text: 'dummy'
+                nexusPolicyEvaluation failBuildOnNetworkError: false, iqApplication: 'app', iqStage: 'stage',
+                  jobCredentialsId: '131-cred'
+              } 
+            } 
+          } 
+        }''')
+      def build = project.scheduleBuild2(0).get()
+
+    then: 'the application is scanned and evaluated using the project user'
+      1 * iqClientBuilder.withServerConfig({ ServerConfig cfg ->
+        cfg.authentication.username == 'project-user'
+      }) >> iqClientBuilder
+      1 * iqClient.verifyOrCreateApplication(*_) >> true
+      1 * iqClient.scan(*_) >> new ScanResult(new Scan(), File.createTempFile('dummy-scan', '.xml.gz'))
+      1 * iqClient.evaluateApplication(*_) >>
+        new ApplicationPolicyEvaluation(0, 1, 2, 3, 11, 12, 13, 0, [createAlert(Action.ID_NOTIFY)],
+          'http://server/link/to/report')
+
+    and: 'the build is successful'
+      jenkins.assertBuildStatusSuccess(build)
+  }
+
+  def 'Declarative pipeline should use global credential id if not job credential id not provided.'() {
+    given: 'a jenkins project'
+      WorkflowJob project = jenkins.createProject(WorkflowJob)
+      configureJenkins()
+
+    when: 'the nexus policy evaluator is executed'
+      project.definition = new CpsFlowDefinition('''
+        pipeline { 
+          agent any 
+          stages { 
+            stage("Example") { 
+              steps { 
+                writeFile file: 'dummy.txt', text: 'dummy'
+                nexusPolicyEvaluation failBuildOnNetworkError: false, iqApplication: 'app', iqStage: 'stage'
+              } 
+            } 
+          } 
+        }''')
+      def build = project.scheduleBuild2(0).get()
+
+    then: 'the application is scanned and evaluated using the project user'
+      1 * iqClientBuilder.withServerConfig({ ServerConfig cfg ->
+        cfg.authentication.username == 'user'
+      }) >> iqClientBuilder
+      1 * iqClient.verifyOrCreateApplication(*_) >> true
+      1 * iqClient.scan(*_) >> new ScanResult(new Scan(), File.createTempFile('dummy-scan', '.xml.gz'))
+      1 * iqClient.evaluateApplication(*_) >>
+        new ApplicationPolicyEvaluation(0, 1, 2, 3, 11, 12, 13, 0, [createAlert(Action.ID_NOTIFY)],
+          'http://server/link/to/report')
+
+    and: 'the build is successful'
+      jenkins.assertBuildStatusSuccess(build)
   }
 
   def configureJenkins() {

--- a/src/test/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorTest.groovy
+++ b/src/test/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorTest.groovy
@@ -267,20 +267,30 @@ class IqPolicyEvaluatorTest
       noExceptionThrown()
   }
 
-  def 'global no credentials are passed to the client builder when no job credentials provided'() {
+  def 'job specific credentials are passed to the client builder'() {
     setup:
-      def buildStep = new IqPolicyEvaluatorBuildStep('stage', new SelectedApplication('appId'), [new ScanPattern('*.jar')], [],
-          true, jobCredentials, null, null)
+      def buildStep = new IqPolicyEvaluatorBuildStep('stage', new SelectedApplication('appId'),
+        [new ScanPattern('*.jar')], [], true, '131-cred', false, null)
 
     when:
       buildStep.perform(run, launcher, Mock(BuildListener))
 
     then:
       1 * iqClient.verifyOrCreateApplication(*_) >> true
-      1 * IqClientFactory.getIqClient { it.credentialsId == jobCredentials } >> iqClient
+      1 * IqClientFactory.getIqClient { it.credentialsId == '131-cred' } >> iqClient
+  }
 
-    where:
-      jobCredentials << [ null, '', '131-cred']
+  def 'global credentials are passed to the client builder when no job credentials provided'() {
+    setup:
+      def buildStep = new IqPolicyEvaluatorBuildStep('stage', new SelectedApplication('appId'),
+        [new ScanPattern('*.jar')], [], true, null, false, null)
+
+    when:
+      buildStep.perform(run, launcher, Mock(BuildListener))
+
+    then:
+      1 * iqClient.verifyOrCreateApplication(*_) >> true
+      1 * IqClientFactory.getIqClient { it.credentialsId == '123-cred-456' } >> iqClient
   }
 
   def 'evaluation result outcome determines build status'() {

--- a/src/test/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorTest.groovy
+++ b/src/test/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorTest.groovy
@@ -269,15 +269,16 @@ class IqPolicyEvaluatorTest
 
   def 'job specific credentials are passed to the client builder'() {
     setup:
+      def credentialsId = '131-cred'
       def buildStep = new IqPolicyEvaluatorBuildStep('stage', new SelectedApplication('appId'),
-        [new ScanPattern('*.jar')], [], true, '131-cred', false, null)
+        [new ScanPattern('*.jar')], [], true, credentialsId, false, null)
 
     when:
       buildStep.perform(run, launcher, Mock(BuildListener))
 
     then:
       1 * iqClient.verifyOrCreateApplication(*_) >> true
-      1 * IqClientFactory.getIqClient { it.credentialsId == '131-cred' } >> iqClient
+      1 * IqClientFactory.getIqClient { it.credentialsId == credentialsId } >> iqClient
   }
 
   def 'global credentials are passed to the client builder when no job credentials provided'() {

--- a/src/test/java/org/sonatype/nexus/ci/util/IqUtilTest.groovy
+++ b/src/test/java/org/sonatype/nexus/ci/util/IqUtilTest.groovy
@@ -50,7 +50,6 @@ class IqUtilTest
 
       GroovyMock(IqClientFactory, global: true)
       def iqClient = Mock(InternalIqClient)
-      IqClientFactory.getIqClient { it.credentialsId == credentialsId && it.context == job } >> iqClient
 
       iqClient.applicationsForApplicationEvaluation >> [
           new ApplicationSummary('id1', 'publicId1', 'name1'),
@@ -61,6 +60,10 @@ class IqUtilTest
       def applicationItems = IqUtil.doFillIqApplicationItems(credentialsId, job)
 
     then:
+      1 * IqClientFactory.getIqClient { IqClientFactoryConfiguration cfg ->
+        cfg.credentialsId == credentialsId && cfg.serverUrl == URI.create(serverUrl) && cfg.context == job
+      } >> iqClient
+
       applicationItems.size() == 3
       applicationItems.get(0).name == FormUtil.EMPTY_LIST_BOX_NAME
       applicationItems.get(0).value == FormUtil.EMPTY_LIST_BOX_VALUE
@@ -99,14 +102,16 @@ class IqUtilTest
       GroovyMock(IqClientFactory, global: true)
       def iqClient = Mock(InternalIqClient)
 
-      IqClientFactory.getIqClient { it.credentialsId == 'jobCredentialsId' && it.context == job } >> iqClient
-
       iqClient.applicationsForApplicationEvaluation >> [new ApplicationSummary('id', 'publicId', 'name')]
 
     when: 'doFillIqApplicationItems is called with specific credentialsId'
       def applicationItems = IqUtil.doFillIqApplicationItems('jobCredentialsId', job)
 
     then:
+      1 * IqClientFactory.getIqClient { IqClientFactoryConfiguration cfg ->
+        cfg.credentialsId == 'jobCredentialsId' && cfg.serverUrl == URI.create(serverUrl) && cfg.context == job
+      } >> iqClient
+
       applicationItems.size() == 2
       applicationItems.get(0).name == FormUtil.EMPTY_LIST_BOX_NAME
       applicationItems.get(0).value == FormUtil.EMPTY_LIST_BOX_VALUE


### PR DESCRIPTION
https://issues.sonatype.org/browse/INT-3589
https://jenkins.ci.sonatype.dev/job/integrations/job/jenkins/job/feature-snapshots/job/INT-3589-decouple-iq-client/

This update makes `IqClientFactory#getIqClient` enforce that callers of that method provide all of the information that is needed to create an `InternalIQClient` rather than fetching some information from static method on `NxiqConfiguration`. That should make it easier in the future to support multiple IQ servers.

Originally opened as https://github.com/jenkinsci/nexus-platform-plugin/pull/128 but that got stale before being merged.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
