### PR TITLE
INT-1446 delete temp files from scan after eval

### DIFF
--- a/src/main/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorUtil.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorUtil.groovy
@@ -95,7 +95,7 @@ class IqPolicyEvaluatorUtil
         evaluationResult = iqClient.evaluateApplication(applicationId, iqStage, scanResult, workDirectory)
       } finally {
         // clean up scan files on master and agent
-        deleteLocalScanResult(scanResult)
+        scanResult?.scanFile?.delete()
         remoteScanResult?.delete()
       }
 
@@ -119,15 +119,6 @@ class IqPolicyEvaluatorUtil
     catch (IqClientException e) {
       return handleNetworkException(iqPolicyEvaluator.failBuildOnNetworkError, e, listener, run)
     }
-  }
-
-  /**
-   * delete the temp scan file referenced in a ScanResult produced as a copy of a RemoteScanResult.
-   * @param scanResult to cleanup
-   * @return true if the file was deleted
-   */
-  private static boolean deleteLocalScanResult(final ScanResult scanResult) {
-    scanResult?.scanFile?.delete()
   }
 
   private static handleNetworkException(final Boolean failBuildOnNetworkError, final IqClientException e,

--- a/src/main/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorUtil.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorUtil.groovy
@@ -14,6 +14,7 @@ package org.sonatype.nexus.ci.iq
 
 import com.sonatype.nexus.api.exception.IqClientException
 import com.sonatype.nexus.api.iq.ApplicationPolicyEvaluation
+import com.sonatype.nexus.api.iq.scan.ScanResult
 
 import org.sonatype.nexus.ci.config.GlobalNexusConfiguration
 import org.sonatype.nexus.ci.config.NxiqConfiguration
@@ -94,7 +95,7 @@ class IqPolicyEvaluatorUtil
         evaluationResult = iqClient.evaluateApplication(applicationId, iqStage, scanResult, workDirectory)
       } finally {
         // clean up scan files on master and agent
-        RemoteScanResult.deleteLocalScanResult(scanResult)
+        deleteLocalScanResult(scanResult)
         remoteScanResult?.delete()
       }
 
@@ -118,6 +119,15 @@ class IqPolicyEvaluatorUtil
     catch (IqClientException e) {
       return handleNetworkException(iqPolicyEvaluator.failBuildOnNetworkError, e, listener, run)
     }
+  }
+
+  /**
+   * delete the temp scan file referenced in a ScanResult produced as a copy of a RemoteScanResult.
+   * @param scanResult to cleanup
+   * @return true if the file was deleted
+   */
+  private static boolean deleteLocalScanResult(final ScanResult scanResult) {
+    scanResult?.scanFile?.delete()
   }
 
   private static handleNetworkException(final Boolean failBuildOnNetworkError, final IqClientException e,

--- a/src/main/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorUtil.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorUtil.groovy
@@ -77,8 +77,9 @@ class IqPolicyEvaluatorUtil
 
       def scanResult
       def evaluationResult
+      def remoteScanResult
       try {
-        def remoteScanResult = launcher.getChannel().call(remoteScanner)
+        remoteScanResult = launcher.getChannel().call(remoteScanner)
         scanResult = remoteScanResult.copyToLocalScanResult()
 
         def repositoryUrlFinder = RemoteRepositoryUrlFinderFactory
@@ -92,7 +93,9 @@ class IqPolicyEvaluatorUtil
         File workDirectory = new File(workspace.getRemote())
         evaluationResult = iqClient.evaluateApplication(applicationId, iqStage, scanResult, workDirectory)
       } finally {
+        // clean up scan files on master and agent
         RemoteScanResult.deleteLocalScanResult(scanResult)
+        remoteScanResult?.delete()
       }
 
       def healthAction = new PolicyEvaluationHealthAction(applicationId, iqStage, run, evaluationResult)

--- a/src/main/java/org/sonatype/nexus/ci/iq/RemoteScanResult.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/iq/RemoteScanResult.groovy
@@ -46,5 +46,4 @@ class RemoteScanResult
   boolean delete() {
     filePath.delete();
   }
-
 }

--- a/src/main/java/org/sonatype/nexus/ci/iq/RemoteScanResult.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/iq/RemoteScanResult.groovy
@@ -35,4 +35,8 @@ class RemoteScanResult
     new FileOutputStream(localFile).withStream { filePath.copyTo(it) }
     return new ScanResult(scan, localFile)
   }
+
+  static boolean deleteLocalScanResult(final ScanResult scanResult) {
+    scanResult?.scanFile?.delete()
+  }
 }

--- a/src/main/java/org/sonatype/nexus/ci/iq/RemoteScanResult.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/iq/RemoteScanResult.groovy
@@ -48,12 +48,4 @@ class RemoteScanResult
     filePath.delete();
   }
 
-  /**
-   * delete the temp scan file referenced in a ScanResult produced as a copy of a RemoteScanResult.
-   * @param scanResult to cleanup
-   * @return true if the file was deleted
-   */
-  static boolean deleteLocalScanResult(final ScanResult scanResult) {
-    scanResult?.scanFile?.delete()
-  }
 }

--- a/src/main/java/org/sonatype/nexus/ci/iq/RemoteScanResult.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/iq/RemoteScanResult.groovy
@@ -41,6 +41,14 @@ class RemoteScanResult
   }
 
   /**
+   * delete the remote scan file from the remote agent
+   * @return true if the file as deleted
+   */
+  boolean delete() {
+    filePath.delete();
+  }
+
+  /**
    * delete the temp scan file referenced in a ScanResult produced as a copy of a RemoteScanResult.
    * @param scanResult to cleanup
    * @return true if the file was deleted

--- a/src/main/java/org/sonatype/nexus/ci/iq/RemoteScanResult.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/iq/RemoteScanResult.groovy
@@ -35,7 +35,6 @@ class RemoteScanResult
    */
   ScanResult copyToLocalScanResult() {
     def localFile = File.createTempFile('scan', '.xml.gz')
-    localFile.deleteOnExit()
     new FileOutputStream(localFile).withStream { filePath.copyTo(it) }
     return new ScanResult(scan, localFile)
   }

--- a/src/main/java/org/sonatype/nexus/ci/iq/RemoteScanResult.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/iq/RemoteScanResult.groovy
@@ -29,6 +29,10 @@ class RemoteScanResult
     this.scan = scan
   }
 
+  /**
+   * create a copy as a ScanResult with a local copy of the scan file
+   * @return a local ScanResult
+   */
   ScanResult copyToLocalScanResult() {
     def localFile = File.createTempFile('scan', '.xml.gz')
     localFile.deleteOnExit()
@@ -36,6 +40,11 @@ class RemoteScanResult
     return new ScanResult(scan, localFile)
   }
 
+  /**
+   * delete the temp scan file referenced in a ScanResult produced as a copy of a RemoteScanResult.
+   * @param scanResult to cleanup
+   * @return true if the file was deleted
+   */
   static boolean deleteLocalScanResult(final ScanResult scanResult) {
     scanResult?.scanFile?.delete()
   }

--- a/src/test/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorTest.groovy
+++ b/src/test/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorTest.groovy
@@ -256,6 +256,7 @@ class IqPolicyEvaluatorTest
       e.message == 'CRASH'
     and: 'no need to delete the temp scan file since it was not created'
       0 * localScanFile.delete()
+      0 * remoteScanResult.delete()
   }
 
   def 'evaluation networking exceptions are suppressed by failBuildOnNetworkError'() {
@@ -274,6 +275,7 @@ class IqPolicyEvaluatorTest
       noExceptionThrown()
     and: 'delete the temp scan file'
       1 * localScanFile.delete() >> true
+      1 * remoteScanResult.delete() >> true
   }
 
   def 'global no credentials are passed to the client builder when no job credentials provided'() {
@@ -307,6 +309,7 @@ class IqPolicyEvaluatorTest
       1 * run.setResult(buildResult)
     and: 'delete the temp scan file'
       1 * localScanFile.delete() >> true
+      1 * remoteScanResult.delete() >> true
 
     where:
       alerts                                                  || buildResult
@@ -336,6 +339,7 @@ class IqPolicyEvaluatorTest
       ex.policyEvaluation == policyEvaluation
     and: 'delete the temp scan file'
       1 * localScanFile.delete() >> true
+      1 * remoteScanResult.delete() >> true
   }
 
   @Unroll
@@ -367,6 +371,7 @@ class IqPolicyEvaluatorTest
       1 * listener.fatalError('IQ Server evaluation of application appId failed')
     and: 'delete the temp scan file'
       1 * localScanFile.delete() >> true
+      1 * remoteScanResult.delete() >> true
 
     where:
       hideReports << [true, false]
@@ -398,6 +403,7 @@ class IqPolicyEvaluatorTest
               ' viewed online at http://server/report\nSummary of policy violations: 11 critical, 12 severe, 13 moderate')
     and: 'delete the temp scan file'
       1 * localScanFile.delete() >> true
+      1 * remoteScanResult.delete() >> true
 
     where:
       hideReports << [true, false]
@@ -424,6 +430,7 @@ class IqPolicyEvaluatorTest
           'Summary of policy violations: 0 critical, 0 severe, 0 moderate')
     and: 'delete the temp scan file'
       1 * localScanFile.delete() >> true
+      1 * remoteScanResult.delete() >> true
   }
 
   def 'prints an error message if not in node context'() {
@@ -471,5 +478,6 @@ class IqPolicyEvaluatorTest
       1 * iqClient.evaluateApplication("appId", "stage", scanResult, _) >> evaluationResult
     and: 'delete the temp scan file'
       1 * localScanFile.delete() >> true
+      1 * remoteScanResult.delete() >> true
   }
 }

--- a/src/test/java/org/sonatype/nexus/ci/iq/RemoteScanResultTest.groovy
+++ b/src/test/java/org/sonatype/nexus/ci/iq/RemoteScanResultTest.groovy
@@ -32,10 +32,6 @@ class RemoteScanResultTest extends Specification
       final scanResult = remoteScanResult.copyToLocalScanResult()
       scanResult.scan == scan
       scanResult.scanFile.text == 'content'
-    when: 'we delete the local copy'
-      RemoteScanResult.deleteLocalScanResult(scanResult)
-    then: 'the local file is gone'
-      ! scanResult.scanFile.exists()
     when: 'we delete the remote scan result'
       remoteScanResult.delete()
     then: 'the file is gone from the agent'

--- a/src/test/java/org/sonatype/nexus/ci/iq/RemoteScanResultTest.groovy
+++ b/src/test/java/org/sonatype/nexus/ci/iq/RemoteScanResultTest.groovy
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2016-present Sonatype, Inc. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package org.sonatype.nexus.ci.iq
+
+import com.sonatype.insight.scan.model.Scan
+
+import hudson.FilePath
+import spock.lang.Specification
+
+class RemoteScanResultTest extends Specification
+{
+  def 'create and delete remote scan results'() {
+    given: 'a file on an agent'
+      File agentFile = File.createTempFile('scan-', '.txt')
+      agentFile.withWriter { w -> w.print('content') }
+      FilePath filePath = new FilePath(agentFile)
+    and: 'a scan'
+      Scan scan = Mock()
+    and: 'a new remote scan result wrapped around the scan and agent file'
+      def remoteScanResult = new RemoteScanResult(scan, filePath)
+    expect: 'we can make a local copy of the result'
+      def scanResult = remoteScanResult.copyToLocalScanResult()
+      scanResult.scan == scan
+      scanResult.scanFile.text == 'content'
+    when: 'we delete the local copy'
+      RemoteScanResult.deleteLocalScanResult(scanResult)
+    then: 'the local file is gone'
+      ! scanResult.scanFile.exists()
+    when: 'we delete the remote scan result'
+      remoteScanResult.delete()
+    then: 'the file is gone from the agent'
+      ! agentFile.exists()
+  }
+}

--- a/src/test/java/org/sonatype/nexus/ci/iq/RemoteScanResultTest.groovy
+++ b/src/test/java/org/sonatype/nexus/ci/iq/RemoteScanResultTest.groovy
@@ -21,15 +21,15 @@ class RemoteScanResultTest extends Specification
 {
   def 'create and delete remote scan results'() {
     given: 'a file on an agent'
-      File agentFile = File.createTempFile('scan-', '.txt')
+      final agentFile = File.createTempFile('scan-', '.txt')
       agentFile.withWriter { w -> w.print('content') }
-      FilePath filePath = new FilePath(agentFile)
+      final filePath = new FilePath(agentFile)
     and: 'a scan'
-      Scan scan = Mock()
+      final Scan scan = Mock()
     and: 'a new remote scan result wrapped around the scan and agent file'
-      def remoteScanResult = new RemoteScanResult(scan, filePath)
+      final remoteScanResult = new RemoteScanResult(scan, filePath)
     expect: 'we can make a local copy of the result'
-      def scanResult = remoteScanResult.copyToLocalScanResult()
+      final scanResult = remoteScanResult.copyToLocalScanResult()
       scanResult.scan == scan
       scanResult.scanFile.text == 'content'
     when: 'we delete the local copy'

--- a/src/test/java/org/sonatype/nexus/ci/iq/RemoteScanResultTest.groovy
+++ b/src/test/java/org/sonatype/nexus/ci/iq/RemoteScanResultTest.groovy
@@ -15,13 +15,18 @@ package org.sonatype.nexus.ci.iq
 import com.sonatype.insight.scan.model.Scan
 
 import hudson.FilePath
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
 
 class RemoteScanResultTest extends Specification
 {
+  @Rule
+  private TemporaryFolder temp = new TemporaryFolder()
+
   def 'create and delete remote scan results'() {
     given: 'a file on an agent'
-      final agentFile = File.createTempFile('scan-', '.txt')
+      final agentFile = temp.newFile()
       agentFile.withWriter { w -> w.print('content') }
       final filePath = new FilePath(agentFile)
     and: 'a scan'


### PR DESCRIPTION
Delete the local copy of the scan file that's created on the master node, so they don't accumulate over time.

JIRA: https://issues.sonatype.org/browse/INT-1446
Build: https://jenkins.ci.sonatype.dev/job/integrations/job/jenkins/job/feature-snapshots/job/INT-1446-tmp-cleanup/
Demo: link on JIRA ticket