### PR TITLE
INTC-183 Make build unstable on scan error count > 0

### DIFF
--- a/src/main/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorUtil.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorUtil.groovy
@@ -110,6 +110,7 @@ class IqPolicyEvaluatorUtil
       }
       
       Result result = handleEvaluationResult(evaluationResult, listener, applicationId, NxiqConfiguration.hideReports)
+      run.setResult(result)
       if (result == Result.FAILURE) {
         throw new PolicyEvaluationException(Messages.IqPolicyEvaluation_EvaluationFailed(applicationId),
             evaluationResult)
@@ -117,8 +118,8 @@ class IqPolicyEvaluatorUtil
 
       if (scanResult.scan.summary.errorCount > 0) {
         result = Result.UNSTABLE;
+        run.setResult(result)
       }
-      run.setResult(result)
 
       return evaluationResult
     }

--- a/src/main/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorUtil.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorUtil.groovy
@@ -116,7 +116,7 @@ class IqPolicyEvaluatorUtil
             evaluationResult)
       }
 
-      if (scanResult.scan != null && scanResult.scan.summary != null && scanResult.scan.summary.errorCount > 0) {
+      if (scanResult.scan?.summary?.errorCount > 0) {
         result = Result.UNSTABLE;
         run.setResult(result)
       }

--- a/src/main/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorUtil.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorUtil.groovy
@@ -116,7 +116,7 @@ class IqPolicyEvaluatorUtil
             evaluationResult)
       }
 
-      if (scanResult.scan.summary != null && scanResult.scan.summary.errorCount > 0) {
+      if (scanResult.scan != null && scanResult.scan.summary != null && scanResult.scan.summary.errorCount > 0) {
         result = Result.UNSTABLE;
         run.setResult(result)
       }

--- a/src/main/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorUtil.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorUtil.groovy
@@ -14,7 +14,6 @@ package org.sonatype.nexus.ci.iq
 
 import com.sonatype.nexus.api.exception.IqClientException
 import com.sonatype.nexus.api.iq.ApplicationPolicyEvaluation
-import com.sonatype.nexus.api.iq.scan.ScanResult
 
 import org.sonatype.nexus.ci.config.GlobalNexusConfiguration
 import org.sonatype.nexus.ci.config.NxiqConfiguration
@@ -111,11 +110,15 @@ class IqPolicyEvaluatorUtil
       }
       
       Result result = handleEvaluationResult(evaluationResult, listener, applicationId, NxiqConfiguration.hideReports)
-      run.setResult(result)
       if (result == Result.FAILURE) {
         throw new PolicyEvaluationException(Messages.IqPolicyEvaluation_EvaluationFailed(applicationId),
             evaluationResult)
       }
+
+      if (scanResult.scan.summary.errorCount > 0) {
+        result = Result.UNSTABLE;
+      }
+      run.setResult(result)
 
       return evaluationResult
     }

--- a/src/main/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorUtil.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorUtil.groovy
@@ -117,8 +117,7 @@ class IqPolicyEvaluatorUtil
       }
 
       if (scanResult.scan?.summary?.errorCount > 0) {
-        result = Result.UNSTABLE;
-        run.setResult(result)
+        run.setResult(Result.UNSTABLE)
       }
 
       return evaluationResult

--- a/src/main/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorUtil.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorUtil.groovy
@@ -116,7 +116,7 @@ class IqPolicyEvaluatorUtil
             evaluationResult)
       }
 
-      if (scanResult.scan.summary.errorCount > 0) {
+      if (scanResult.scan.summary != null && scanResult.scan.summary.errorCount > 0) {
         result = Result.UNSTABLE;
         run.setResult(result)
       }

--- a/src/test/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorTest.groovy
+++ b/src/test/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorTest.groovy
@@ -375,15 +375,16 @@ class IqPolicyEvaluatorTest
 
   def 'evaluation throws exception when build results in failure with error count'() {
     setup:
-      def buildStep = new IqPolicyEvaluatorBuildStep('stage', new SelectedApplication('appId'), [new ScanPattern('*.jar')], [],
-          false, '131-cred', null, null)
-      def policyEvaluation = new ApplicationPolicyEvaluation(0, 0, 0, 0, 0, 0, 0, 0, 0,
-          [new PolicyAlert(null, [new Action(Action.ID_FAIL)])], reportUrl)
       def scan = Mock(Scan)
       def summary = Mock(ScanSummary)
       scanResult.scan >> scan
       scan.summary >> summary
       summary.errorCount >> 1
+
+      def buildStep = new IqPolicyEvaluatorBuildStep('stage', new SelectedApplication('appId'), [new ScanPattern('*.jar')], [],
+          false, '131-cred', null, null)
+      def policyEvaluation = new ApplicationPolicyEvaluation(0, 0, 0, 0, 0, 0, 0, 0, 0,
+          [new PolicyAlert(null, [new Action(Action.ID_FAIL)])], reportUrl)
 
     when:
       buildStep.perform(run, launcher, Mock(BuildListener))

--- a/src/test/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorTest.groovy
+++ b/src/test/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorTest.groovy
@@ -12,6 +12,8 @@
  */
 package org.sonatype.nexus.ci.iq
 
+import com.sonatype.insight.scan.model.Scan
+import com.sonatype.insight.scan.model.ScanSummary
 import com.sonatype.nexus.api.exception.IqClientException
 import com.sonatype.nexus.api.iq.Action
 import com.sonatype.nexus.api.iq.ApplicationPolicyEvaluation
@@ -317,6 +319,34 @@ class IqPolicyEvaluatorTest
       []                                                      || Result.SUCCESS
       [new PolicyAlert(null, [new Action(Action.ID_WARN)])]   || Result.UNSTABLE
       [new PolicyAlert(null, [new Action(Action.ID_NOTIFY)])] || Result.SUCCESS
+  }
+
+  def 'evaluation summary error count determines unstable status'() {
+    setup:
+      def buildStep = new IqPolicyEvaluatorBuildStep('stage', new SelectedApplication('appId'), [new ScanPattern('*.jar')], [],
+          false, '131-cred', null, null)
+      def scan = Mock(Scan)
+      def summary = Mock(ScanSummary)
+      scanResult.scan >> scan
+      scan.summary >> summary
+      summary.errorCount >> 1
+
+    when:
+      buildStep.perform(run, launcher, Mock(BuildListener))
+
+    then:
+      1 * iqClient.verifyOrCreateApplication(*_) >> true
+      1 * iqClient.evaluateApplication('appId', 'stage', scanResult, _) >>
+          new ApplicationPolicyEvaluation(0, 0, 0, 0, 0, 0, 0, 0, 0, alerts, reportUrl)
+      1 * run.setResult(buildResult)
+    and: 'delete the temp scan file'
+      1 * localScanFile.delete() >> true
+      1 * remoteScanResult.delete() >> true
+
+    where:
+      alerts                                                  || buildResult
+      []                                                      || Result.UNSTABLE
+      [new PolicyAlert(null, [new Action(Action.ID_NOTIFY)])] || Result.UNSTABLE
   }
 
   def 'evaluation throws exception when build results in failure'() {

--- a/src/test/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorTest.groovy
+++ b/src/test/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorTest.groovy
@@ -392,6 +392,7 @@ class IqPolicyEvaluatorTest
       1 * iqClient.verifyOrCreateApplication(*_) >> true
       1 * iqClient.evaluateApplication('appId', 'stage', scanResult, _) >> policyEvaluation
       1 * run.setResult(Result.FAILURE)
+      0 * run.setResult(Result.UNSTABLE)
 
     and:
       PolicyEvaluationException ex = thrown()


### PR DESCRIPTION
On scan error count > 0, set build status to `unstable`

Jira: https://issues.sonatype.org/browse/INTC-183
Jenkins: https://jenkins.ci.sonatype.dev/job/integrations/job/jenkins/job/feature-snapshots/job/INTC-183-container-for-jenkins-error/