### PR TITLE
Fix assertion in RemoteScannerTest

### DIFF
--- a/src/test/java/org/sonatype/nexus/ci/iq/RemoteScannerTest.groovy
+++ b/src/test/java/org/sonatype/nexus/ci/iq/RemoteScannerTest.groovy
@@ -92,7 +92,7 @@ class RemoteScannerTest
 
     then:
       iqClient.scan(*_) >> { arguments ->
-        arguments[3] == ['container:alpine:3.6']
+        assert arguments[3][0] == new File('container:alpine:3.6')
 
         new ScanResult(null, new File('container:alpine:3.6'))
       }


### PR DESCRIPTION
Fix the assertion in RemoteScannerTest.groovy file. The current statement was missing the `assert` keyword, hence not doing any assertions. 