### PR TITLE
Replaced jaxb with jackson for xml deserialization (to avoid jaxb class loading problems in Jenkins) INT-6159

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
     <forkCount>1</forkCount>
     <java.level>8</java.level>
     <slf4j.version>1.7.7</slf4j.version>
-    <nexus-platform-api.version>3.44.7-01</nexus-platform-api.version>
+    <nexus-platform-api.version>3.44.8-SNAPSHOT</nexus-platform-api.version>
 
     <buildsupport.version>10</buildsupport.version>
     <buildsupport.license-maven-plugin.version>2.11</buildsupport.license-maven-plugin.version>
@@ -206,6 +206,28 @@
   </dependencyManagement>
 
   <dependencies>
+    <!--
+    Include these dependencies if you need to debug Stax in Jenkins.
+    We exclude stax:stax-api because it doesn't have sources and 
+    replace it with javax.xml.stream:stax-api because it has sources.
+    <dependency>
+      <groupId>stax</groupId>
+      <artifactId>stax</artifactId>
+      <version>1.2.0</version>
+      <exclusions>
+        <exclusion>
+          <groupId>stax</groupId>
+          <artifactId>stax-api</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>javax.xml.stream</groupId>
+      <artifactId>stax-api</artifactId>
+      <version>1.0-2</version>
+    </dependency>
+    -->
+
     <dependency>
       <groupId>com.sonatype.nexus</groupId>
       <artifactId>nexus-platform-api</artifactId>


### PR DESCRIPTION
https://issues.sonatype.org/browse/INT-6159

I'll run a CI build after the nexus-java-api PR is merged to main.