### PR TITLE
Use clm-maven-plugin INT-6112

### DIFF
--- a/Jenkinsfile.sonatype
+++ b/Jenkinsfile.sonatype
@@ -41,7 +41,7 @@ Closure iqPolicyEvaluation = {
 
     try {
       def evaluation = nexusPolicyEvaluation failBuildOnNetworkError: false, iqApplication: 'nexus-platform-plugin',
-          iqScanPatterns: [[scanPattern: 'target/nexus-jenkins-plugin.hpi']], iqStage: stage, jobCredentialsId: ''
+          iqScanPatterns: [[scanPattern: 'scan_nothing']], iqStage: stage, jobCredentialsId: ''
       gitHub.statusUpdate commitId, 'success', 'analysis', 'Nexus Lifecycle Analysis passed',
           "${evaluation.applicationCompositionReportUrl}"
     }

--- a/pom.xml
+++ b/pom.xml
@@ -490,6 +490,21 @@
           </headerDefinitions>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>com.sonatype.clm</groupId>
+        <artifactId>clm-maven-plugin</artifactId>
+        <version>2.28.0-01</version>
+        <configuration>
+          <skip>false</skip>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>index</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
https://issues.sonatype.org/browse/INT-6112
https://jenkins.ci.sonatype.dev/job/integrations/job/jenkins/job/feature-snapshots/job/INT-6112_UseClmMavenPlugin/

I enabled clm-maven-plugin to get a more accurate BOM (instead of scanning the binary).