### PR TITLE
INTC-375 - Ensure IaC scans are supported in the Jenkins plugin

### DIFF
--- a/src/main/java/org/sonatype/nexus/ci/iq/RemoteScanner.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/iq/RemoteScanner.groovy
@@ -31,6 +31,8 @@ class RemoteScanner
 
   public static final String CONTAINER = 'container:'
 
+  public static final String IAC = 'iac:'
+
   private final String appId
 
   private final String stageId
@@ -90,6 +92,13 @@ class RemoteScanner
       if (pattern.startsWith(CONTAINER)) {
         targets = targets.toList()
         targets.add(new File(pattern))
+        targets = Collections.unmodifiableList(targets)
+      }
+      else if (pattern.startsWith(IAC)) {
+        def iacTarget = IAC + workDirectory + File.separatorChar + pattern.substring(4, pattern.length())
+        log.debug("Adding iac scan target:" + iacTarget)
+        targets = targets.toList()
+        targets.add(new File(iacTarget))
         targets = Collections.unmodifiableList(targets)
       }
     }

--- a/src/test/java/org/sonatype/nexus/ci/iq/RemoteScannerTest.groovy
+++ b/src/test/java/org/sonatype/nexus/ci/iq/RemoteScannerTest.groovy
@@ -101,6 +101,27 @@ class RemoteScannerTest
       workspace = new FilePath(new File('/file/path'))
   }
 
+  def "creates a list of iac targets from the result of a directory scan"() {
+    setup:
+      def remoteScanner = new RemoteScanner('appId', 'stageId', ['iac:iac.tf'], [], workspace, proprietaryConfig, log,
+          "instance-id", null, null)
+      directoryScanner.getIncludedDirectories() >> []
+      directoryScanner.getIncludedFiles() >> []
+
+    when:
+      remoteScanner.call()
+
+    then:
+      iqClient.scan(*_) >> { arguments ->
+        assert arguments[3][0] == new File('iac:/file/path/iac.tf')
+
+        new ScanResult(null, new File('iac:/file/path/iac.tf'))
+      }
+
+    where:
+      workspace = new FilePath(new File('/file/path'))
+  }
+
   def 'creates a list of module indices from the results of a directory scan'() {
     setup:
       def remoteScanner = new RemoteScanner('appId', 'stageId', ['*jar'], [], workspace, proprietaryConfig, log,


### PR DESCRIPTION
https://issues.sonatype.org/browse/INTC-375
https://jenkins.ci.sonatype.dev/job/integrations/job/jenkins/job/feature-snapshots/job/INTC-375_Ensure_IaC_scans_are_supported_in_the_Jenkins_plugin/

Demo: https://drive.google.com/file/d/1AMAaWuium-bKLOOlmdMxNVbDYUJxP4AF/view?usp=sharing