### PR TITLE
Tweak repetitive logging - INT-6005

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
     <jvnet-localizer-plugin.version>1.23</jvnet-localizer-plugin.version>
     <forkCount>1</forkCount>
     <java.level>8</java.level>
-    <nexus-platform-api.version>3.48.2-01</nexus-platform-api.version>
+    <nexus-platform-api.version>3.48.3-SNAPSHOT</nexus-platform-api.version>
 
     <buildsupport.version>10</buildsupport.version>
     <buildsupport.license-maven-plugin.version>2.11</buildsupport.license-maven-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
     <jvnet-localizer-plugin.version>1.23</jvnet-localizer-plugin.version>
     <forkCount>1</forkCount>
     <java.level>8</java.level>
-    <nexus-platform-api.version>3.48.3</nexus-platform-api.version>
+    <nexus-platform-api.version>3.48.3-01</nexus-platform-api.version>
 
     <buildsupport.version>10</buildsupport.version>
     <buildsupport.license-maven-plugin.version>2.11</buildsupport.license-maven-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
     <jvnet-localizer-plugin.version>1.23</jvnet-localizer-plugin.version>
     <forkCount>1</forkCount>
     <java.level>8</java.level>
-    <nexus-platform-api.version>3.48.3-SNAPSHOT</nexus-platform-api.version>
+    <nexus-platform-api.version>3.48.3</nexus-platform-api.version>
 
     <buildsupport.version>10</buildsupport.version>
     <buildsupport.license-maven-plugin.version>2.11</buildsupport.license-maven-plugin.version>


### PR DESCRIPTION
#### Description
The purpose of this change is to switch the log entries like "...Finished scanning target: ..." from INFO to DEBUG level. 

This is a draft PR just to prove that all tests pass. After approval I intend to release `nexus-java-api` and update its version here, so the testing is done against the release version.

#### Links
Jira: https://issues.sonatype.org/browse/INT-6005
Build: https://jenkins.ci.sonatype.dev/job/integrations/job/jenkins/job/feature-snapshots/job/INT-6005-logging-tweak/