### PR TITLE
INT-6477 Using shared library to update the release notes

### DIFF
--- a/Jenkinsfile.sonatype.bump-up-api
+++ b/Jenkinsfile.sonatype.bump-up-api
@@ -6,7 +6,7 @@
 @Library(['private-pipeline-library', 'jenkins-shared', 'int-jenkins-shared']) _
 
 node('ubuntu-zion') {
-  def platformApiVersion, branch
+  def platformApiVersion, branch, currentPlatformApiVersion
 
   stage('Preparation') {
     deleteDir()
@@ -19,7 +19,19 @@ node('ubuntu-zion') {
     // Setup common variables
     platformApiVersion = getVersionFromBuildName(env.platformApiBuild_NAME)
     branch = 'main'
+
+    // Getting current nexus platform API version
+    pom = readMavenPom file: 'pom.xml'
+    currentPlatformApiVersion = pom.properties['nexus-platform-api.version']
   }
+
+  // Checking if bump is needed
+  if (platformApiVersion.equals(currentPlatformApiVersion)) {
+    echo "Nexus Platform API is already at version ${platformApiVersion}"
+    currentBuild.result = 'UNSTABLE'
+    return
+  }
+
   stage('Bump Nexus Platform API Version') {
     mvn jenkinsMavenConfig(), 'org.codehaus.mojo:versions-maven-plugin:2.8.1:set-property -DgenerateBackupPoms=false ' +
       "-DnewVersion=${platformApiVersion} -Dproperty=nexus-platform-api.version"

--- a/Jenkinsfile.sonatype.release
+++ b/Jenkinsfile.sonatype.release
@@ -171,12 +171,12 @@ void iqPolicyEvaluation(gitHub, stage) {
 void updateChangeLogs(releaseNotes, version, addIQReleaseNotesLink) {
   def newDate = getFormattedCommitDate()
   updateReleaseNotes(
-      'Changelog\n=========',
-      "${version} (${newDate})",
-      '------------------------------------------------',
-      releaseNotes,
-      'README.md',
-      addIQReleaseNotesLink
+      header: 'Changelog\n=========',
+      version: "${version} (${newDate})",
+      separator: '------------------------------------------------',
+      releaseNotes: releaseNotes,
+      filePath: 'README.md',
+      addIQReleaseNotesLink: addIQReleaseNotesLink
   )
 }
 
@@ -204,7 +204,8 @@ void checkPublishedPlugin(version) {
       error 'Plugin artifacts not found.'
     }
   }
-  catch (error) {
+  catch (exception) {
+    echo "Error: ${exception.message}"
     error 'Error checking published plugin artifacts.'
   }
 }

--- a/Jenkinsfile.sonatype.release
+++ b/Jenkinsfile.sonatype.release
@@ -34,6 +34,7 @@ node('ubuntu-zion') {
       commitDate = runSafely("git show -s --format=%cd --date=format:%Y%m%d-%H%M%S ${commitId}", true)
       version = pom.version.replace("-SNAPSHOT", ".${commitDate}.${commitId.substring(0, 7)}")
       releaseNotes = params.releaseNotes
+      addIQReleaseNotesLink = params.addIQReleaseNotesLink
       branch = 'main'
 
       // Setup maven commands
@@ -46,9 +47,6 @@ node('ubuntu-zion') {
 
       // Update display name
       currentBuild.displayName = "#${currentBuild.number} - ${version}"
-
-      // Get flag to add IQ release notes link to change log
-      addIQReleaseNotesLink = params.addIQReleaseNotesLink
     }
     stage('License Check') {
       licenseCheck(jenkinsMavenConfig())
@@ -75,6 +73,12 @@ node('ubuntu-zion') {
     return
   }
   stage('Update and push code') {
+    // Check if want to update the change log
+    if(!releaseNotes && !addIQReleaseNotesLink) {
+      echo 'Skipping change log update'
+      return
+    }
+
     // Update change logs
     updateChangeLogs(releaseNotes, version, addIQReleaseNotesLink)
 
@@ -165,54 +169,15 @@ void iqPolicyEvaluation(gitHub, stage) {
 }
 
 void updateChangeLogs(releaseNotes, version, addIQReleaseNotesLink) {
-  if(!releaseNotes && !addIQReleaseNotesLink) {
-    echo 'Skipping change log update'
-    return
-  }
-
   def newDate = getFormattedCommitDate()
-  def newEntry = createNewChangeLogEntry(releaseNotes, version, newDate, addIQReleaseNotesLink)
-
-  updateReadmeFile('README.md', 'Changelog\n=========', newEntry)
-}
-
-String createNewChangeLogEntry(releaseNotes, version, newDate, addIQReleaseNotesLink) {
-  def iqVersion = addIQReleaseNotesLink ? latestSuccessfulBuild.version('insight/insight-brain/release') : null
-  return """Changelog
-=========
-${version} (${newDate})
-------------------------------------------------
-${getReleaseNotesSummary(releaseNotes, iqVersion)}
-"""
-}
-
-String getReleaseNotesSummary(releaseNotes, iqVersion) {
-  if (iqVersion) {
-    return """
-${releaseNotes}
-${getIQReleaseNotesLogEntry(iqVersion)}
-"""
-  } else {
-    return """
-${releaseNotes}
-"""
-  }
-}
-
-String getIQReleaseNotesLogEntry(iqVersion) {
-  return '- Provide [latest features](https://help.sonatype.com/iqserver/product-information/release-notes#)' +
-      "for Nexus Lifecycle ${iqVersion}."
-}
-
-void updateReadmeFile(readmeFilePath, releaseNotesHeader, releaseNotesEntry) {
-  try {
-    def readmeFile = readFile(readmeFilePath)
-    def updatedReadme = readmeFile.replace(releaseNotesHeader, releaseNotesEntry)
-    writeFile(file: readmeFilePath, text: updatedReadme)
-  }
-  catch (error) {
-    error 'Error updating README file'
-  }
+  updateReleaseNotes(
+      'Changelog\n=========',
+      "${version} (${newDate})",
+      '------------------------------------------------',
+      releaseNotes,
+      'README.md',
+      addIQReleaseNotesLink
+  )
 }
 
 String getFormattedCommitDate() {

--- a/Jenkinsfile.sonatype.release
+++ b/Jenkinsfile.sonatype.release
@@ -170,9 +170,9 @@ void iqPolicyEvaluation(gitHub, stage) {
 
 void updateChangeLogs(releaseNotes, version, addIQReleaseNotesLink) {
   def newDate = getFormattedCommitDate()
-  updateReleaseNotes(
+  updateReleaseNotesMarkdown(
       header: 'Changelog\n=========',
-      version: "${version} (${newDate})",
+      versionHeader: "${version} (${newDate})",
       separator: '------------------------------------------------',
       releaseNotes: releaseNotes,
       filePath: 'README.md',

--- a/Jenkinsfile.sonatype.release
+++ b/Jenkinsfile.sonatype.release
@@ -16,7 +16,8 @@ withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'integr
 GitHub gitHub = new GitHub(this, 'jenkinsci/nexus-platform-plugin', apiToken)
 
 node('ubuntu-zion') {
-  def commitId, commitDate, pom, version, mvnReleaseCommand, mvnDeployCommand, releaseNotes, branch
+  def commitId, commitDate, pom, version, mvnReleaseCommand, mvnDeployCommand
+  def releaseNotes, branch, addIQReleaseNotesLink
 
   try {
     stage('Preparation') {
@@ -45,6 +46,9 @@ node('ubuntu-zion') {
 
       // Update display name
       currentBuild.displayName = "#${currentBuild.number} - ${version}"
+
+      // Get flag to add IQ release notes link to change log
+      addIQReleaseNotesLink = params.addIQReleaseNotesLink
     }
     stage('License Check') {
       licenseCheck(jenkinsMavenConfig())
@@ -72,7 +76,7 @@ node('ubuntu-zion') {
   }
   stage('Update and push code') {
     // Update change logs
-    updateChangeLogs(releaseNotes, version)
+    updateChangeLogs(releaseNotes, version, addIQReleaseNotesLink)
 
     // Add and commit changes
     runSafely 'git add README.md'
@@ -160,33 +164,55 @@ void iqPolicyEvaluation(gitHub, stage) {
   }
 }
 
-void updateChangeLogs(releaseNotes, version) {
-  try {
-    if(!releaseNotes) {
-      echo 'Skipping change log update. No release notes found'
-      return
-    }
-
-    newDate = getFormattedCommitDate()
-    def newEntry = createNewChangeLogEntry(releaseNotes, version, newDate)
-
-    // Update README file
-    def readmeFile = readFile('README.md')
-    def updatedReadme = readmeFile.replace('Changelog\n=========', newEntry)
-    writeFile(file: 'README.md', text: updatedReadme)
+void updateChangeLogs(releaseNotes, version, addIQReleaseNotesLink) {
+  if(!releaseNotes && !addIQReleaseNotesLink) {
+    echo 'Skipping change log update'
+    return
   }
-  catch (error) {
-    error 'Error updating README file'
-  }
+
+  def newDate = getFormattedCommitDate()
+  def newEntry = createNewChangeLogEntry(releaseNotes, version, newDate, addIQReleaseNotesLink)
+
+  updateReadmeFile('README.md', 'Changelog\n=========', newEntry)
 }
 
-String createNewChangeLogEntry(releaseNotes, version, newDate) {
+String createNewChangeLogEntry(releaseNotes, version, newDate, addIQReleaseNotesLink) {
+  def iqVersion = addIQReleaseNotesLink ? latestSuccessfulBuild.version('insight/insight-brain/release') : null
   return """Changelog
 =========
 ${version} (${newDate})
 ------------------------------------------------
+${getReleaseNotesSummary(releaseNotes, iqVersion)}
+"""
+}
+
+String getReleaseNotesSummary(releaseNotes, iqVersion) {
+  if (iqVersion) {
+    return """
+${releaseNotes}
+${getIQReleaseNotesLogEntry(iqVersion)}
+"""
+  } else {
+    return """
 ${releaseNotes}
 """
+  }
+}
+
+String getIQReleaseNotesLogEntry(iqVersion) {
+  return '- Provide [latest features](https://help.sonatype.com/iqserver/product-information/release-notes#)' +
+      "for Nexus Lifecycle ${iqVersion}."
+}
+
+void updateReadmeFile(readmeFilePath, releaseNotesHeader, releaseNotesEntry) {
+  try {
+    def readmeFile = readFile(readmeFilePath)
+    def updatedReadme = readmeFile.replace(releaseNotesHeader, releaseNotesEntry)
+    writeFile(file: readmeFilePath, text: updatedReadme)
+  }
+  catch (error) {
+    error 'Error updating README file'
+  }
 }
 
 String getFormattedCommitDate() {


### PR DESCRIPTION
In this PR we are using a shared library to update the release notes. We are also adding a new boolean parameter to determine if we want to add to the release notes a link to IQ release notes.

The function used to update the release notes is part of this other PR: https://github.com/sonatype/int-jenkins-shared/pull/12

JIRA: https://issues.sonatype.org/browse/INT-6477
Build: https://jenkins.ci.sonatype.dev/job/integrations/job/jenkins/job/feature-snapshots/job/INT-6477-adjusting-jenkins-release-script/