### PR TITLE
INT-6770 Adjusting no proxy hosts validation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
     <jvnet-localizer-plugin.version>1.23</jvnet-localizer-plugin.version>
     <forkCount>1</forkCount>
     <java.level>8</java.level>
-    <nexus-platform-api.version>3.48.8-01</nexus-platform-api.version>
+    <nexus-platform-api.version>3.48.9-SNAPSHOT</nexus-platform-api.version>
 
     <buildsupport.version>10</buildsupport.version>
     <buildsupport.license-maven-plugin.version>2.11</buildsupport.license-maven-plugin.version>

--- a/src/main/java/org/sonatype/nexus/ci/iq/IqClientFactory.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/iq/IqClientFactory.groovy
@@ -49,7 +49,7 @@ class IqClientFactory
     def credentialsId = conf.credentialsId ?: firstIqConfig?.credentialsId
     def credentials = findCredentials(serverUrl, credentialsId, context)
     def serverConfig = getServerConfig(serverUrl, credentials)
-    def proxyConfig = getProxyConfig(serverUrl)
+    def proxyConfig = getProxyConfig()
     return (InternalIqClient) InternalIqClientBuilder.create()
         .withServerConfig(serverConfig)
         .withProxyConfig(proxyConfig)
@@ -66,10 +66,10 @@ class IqClientFactory
         .build()
   }
 
-  static ProxyConfig getProxyConfig(URI url) {
+  static ProxyConfig getProxyConfig() {
     def jenkinsProxy = Jenkins.instance.proxy
 
-    if (jenkinsProxy && ProxyUtil.shouldProxyForUri(jenkinsProxy, url)) {
+    if (jenkinsProxy) {
       return ProxyUtil.newProxyConfig(jenkinsProxy)
     } else {
       return null

--- a/src/main/java/org/sonatype/nexus/ci/iq/RemoteScanner.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/iq/RemoteScanner.groovy
@@ -96,7 +96,7 @@ class RemoteScanner
       }
       else if (pattern.startsWith(IAC)) {
         def iacTarget = IAC + workDirectory + File.separatorChar + pattern.substring(4, pattern.length())
-        log.debug("Adding iac scan target:" + iacTarget)
+        log.debug("Adding iac scan target: ${iacTarget}")
         targets = targets.toList()
         targets.add(new File(iacTarget))
         targets = Collections.unmodifiableList(targets)

--- a/src/main/java/org/sonatype/nexus/ci/util/ProxyUtil.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/util/ProxyUtil.groovy
@@ -32,17 +32,10 @@ class ProxyUtil
   }
 
   static Authentication getProxyAuthentication(ProxyConfiguration proxy) {
-    if (!proxy.userName) {
-      return null
-    }
-    return new Authentication(proxy.userName, proxy.password)
+    return proxy.userName ? new Authentication(proxy.userName, proxy.password) : null
   }
 
   static List<String> getNoProxyHostsList(String noProxyHost) {
-    if (!noProxyHost) {
-      return Collections.emptyList()
-    }
-    String[] excludedHosts = noProxyHost.split('[ \t\n,|]+')
-    return Arrays.asList(excludedHosts)
+    return noProxyHost ? Arrays.asList(noProxyHost.split('[ \t\n,|]+')) :Collections.emptyList()
   }
 }

--- a/src/main/java/org/sonatype/nexus/ci/util/ProxyUtil.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/util/ProxyUtil.groovy
@@ -36,6 +36,6 @@ class ProxyUtil
   }
 
   static List<String> getNoProxyHostsList(String noProxyHost) {
-    return noProxyHost ? Arrays.asList(noProxyHost.split('[ \t\n,|]+')) :Collections.emptyList()
+    return noProxyHost ? Arrays.asList(noProxyHost.split('[ \t\n,|]+')) : Collections.emptyList()
   }
 }

--- a/src/main/java/org/sonatype/nexus/ci/util/ProxyUtil.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/util/ProxyUtil.groovy
@@ -26,11 +26,23 @@ class ProxyUtil
   }
 
   static ProxyConfig newProxyConfig(ProxyConfiguration proxy) {
-    if (proxy.userName) {
-      def authentication = new Authentication(proxy.userName, proxy.password)
-      return new ProxyConfig(proxy.name, proxy.port, authentication)
-    } else {
-      return new ProxyConfig(proxy.name, proxy.port)
+    def noProxyHostsList = getNoProxyHostsList(proxy.noProxyHost)
+    def authentication = getProxyAuthentication(proxy)
+    return new ProxyConfig(proxy.name, proxy.port, authentication, noProxyHostsList)
+  }
+
+  static Authentication getProxyAuthentication(ProxyConfiguration proxy) {
+    if (!proxy.userName) {
+      return null
     }
+    return new Authentication(proxy.userName, proxy.password)
+  }
+
+  static List<String> getNoProxyHostsList(String noProxyHost) {
+    if (!noProxyHost) {
+      return Collections.emptyList()
+    }
+    String[] excludedHosts = noProxyHost.split('[ \t\n,|]+')
+    return Arrays.asList(excludedHosts)
   }
 }

--- a/src/main/java/org/sonatype/nexus/ci/util/RepositoryManagerClientUtil.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/util/RepositoryManagerClientUtil.groovy
@@ -90,7 +90,7 @@ class RepositoryManagerClientUtil
         withServerConfig(getServerConfig(uri, credentialsId))
     def jenkinsProxy = Jenkins.instance.proxy
 
-    if (jenkinsProxy && ProxyUtil.shouldProxyForUri(jenkinsProxy, uri)) {
+    if (jenkinsProxy) {
       clientBuilder.withProxyConfig(ProxyUtil.newProxyConfig(jenkinsProxy))
     }
 

--- a/src/test/java/org/sonatype/nexus/ci/util/ProxyUtilTest.groovy
+++ b/src/test/java/org/sonatype/nexus/ci/util/ProxyUtilTest.groovy
@@ -68,6 +68,25 @@ class ProxyUtilTest
       proxyConfig.host == 'localhost'
       proxyConfig.port == 9080
       proxyConfig.authentication == null
+      proxyConfig.noProxyHosts == []
+  }
+
+  def 'builds proxy config with no proxy hosts'() {
+    setup:
+      def jenkinsProxy = GroovyMock(ProxyConfiguration)
+      jenkinsProxy.userName >> null
+      jenkinsProxy.name >> 'localhost'
+      jenkinsProxy.port >> 9080
+      jenkinsProxy.noProxyHost >> '*.demo'
+
+    when:
+      def proxyConfig = ProxyUtil.newProxyConfig(jenkinsProxy)
+
+    then:
+      proxyConfig.host == 'localhost'
+      proxyConfig.port == 9080
+      proxyConfig.authentication == null
+      proxyConfig.noProxyHosts == ['*.demo']
   }
 
   def 'builds proxy config with authentication'() {
@@ -86,5 +105,6 @@ class ProxyUtilTest
       proxyConfig.port == 9080
       proxyConfig.authentication.username == 'proxy-user'
       proxyConfig.authentication.password as String == 'proxy-pass'
+      proxyConfig.noProxyHosts == []
   }
 }


### PR DESCRIPTION
#### Description
Delegating no proxy hosts validation to `NXRM` and `IQ` HTTP client builders. This change is complemented with the next PR: https://github.com/sonatype/nexus-java-api/pull/201

After this change:
* IQ client and NXRM client will behave consistently with the Proxy setup. 
* Both of them will support JVM setup
```bash
-Dhttp.proxyHost=127.0.0.1 
-Dhttp.proxyPort=8080
-Dhttp.nonProxyHosts="*.demo" 
```
* Both of them will support proxy setup through the **Manage Jenkins > Manage Plugins > Advanced** tab 
* If **JVM** and **Advanced** tab are both configured, then the plugin will take the configuration from *Jenkins*

#### JIRA Link
JIRA: https://issues.sonatype.org/browse/INT-6770
Build: https://jenkins.ci.sonatype.dev/job/integrations/job/jenkins/job/feature-snapshots/job/INT-6770-adjust-no-proxy-hosts-validation/