### PR TITLE
INT-6741 Create support script to get plugins details

### DIFF
--- a/support/README.md
+++ b/support/README.md
@@ -1,0 +1,20 @@
+<!--
+
+    Copyright (c) 2016-present Sonatype, Inc. All rights reserved.
+
+    This program is licensed to you under the Apache License Version 2.0,
+    and you may not use this file except in compliance with the Apache License Version 2.0.
+    You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the Apache License Version 2.0 is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+
+-->
+
+# Support Scripts
+This folder contains scripts that are intended only for support purposes. 
+
+To run the scripts, you will need to go to the [Script Console](https://www.jenkins.io/doc/book/managing/script-console/) 
+on the Jenkins server, paste the script, and hit the **Run** button.  

--- a/support/print-plugins-information-script.groovy
+++ b/support/print-plugins-information-script.groovy
@@ -1,10 +1,10 @@
 /**
- * This script is intend for support purposes only. The script do not get any sensitive information, it only gets
- * information about the installed plugins on the Jenkins server, the packages loaded by each
- * plugin and information about how some classes are loaded by Jenkins.
+ * This script is intended for support purposes only. The script do not get any sensitive information, it only gets
+ * information about the installed plugins on the Jenkins server, the packages loaded by each plugin, and information
+ * about how some classes are loaded by Jenkins.
  *
- * To run the script, you will need to go to the Script Console on Jenkins server, paste the script and hit
- * the "Run" button. Here you have more information:
+ * To run the script, you will need to go to the Script Console on the Jenkins server, paste the script, and hit the
+ * "Run" button. Here you have more information:
  * ---> https://www.jenkins.io/doc/book/managing/script-console/
  */
 

--- a/support/print-plugins-information-script.groovy
+++ b/support/print-plugins-information-script.groovy
@@ -1,0 +1,88 @@
+/**
+ * This script is intend for support purposes only. The script do not get any sensitive information, it only gets
+ * information about the installed plugins on the Jenkins server, the packages loaded by each
+ * plugin and information about how some classes are loaded by Jenkins.
+ *
+ * To run the script, you will need to go to the Script Console on Jenkins server, paste the script and hit
+ * the "Run" button. Here you have more information:
+ * ---> https://www.jenkins.io/doc/book/managing/script-console/
+ */
+
+// Print plugins loading classes
+printPluginsLoadingClasses()
+
+// Prints plugins information
+printPluginsInformation()
+
+// Prints plugins class loaders information
+printClassLoaderInformationForPlugins()
+
+/**
+ * Prints information about how Jenkins is loading some classes
+ */
+def printPluginsLoadingClasses() {
+  println 'Looking for Plugins Loading Classes'
+  println '############################################################'
+  println ''
+  def classesToFind = [
+      "com.sun.org.apache.xerces.internal.jaxp.DocumentBuilderFactoryImpl",
+      "org.cyclonedx.generators.xml.AbstractBomXmlGenerator",
+  ]
+  for (className in classesToFind) {
+    printPluginsLoadingClass(className)
+  }
+}
+
+def printPluginsLoadingClass(className) {
+  def clazzResource = className.replaceAll("\\.", "/") + ".class"
+  println "Looking for: ${clazzResource}"
+  println '-------------------------------------------------------------'
+  def list = []
+  Jenkins.instance.pluginManager.activePlugins.forEach { PluginWrapper plugin ->
+    def c = plugin.classLoader.getResources(clazzResource)
+    if (c.hasMoreElements()) {
+      list.add(plugin.toString())
+    }
+  }
+  println "Class found in: ${list}"
+  println ''
+}
+
+/**
+ * Prints information about installed plugins on Jenkins server
+ */
+def printPluginsInformation() {
+  println 'Looking for Plugins Information'
+  println '############################################################'
+  println ''
+  Jenkins.instance.pluginManager.activePlugins.forEach { PluginWrapper plugin ->
+    println "Found: ${plugin}"
+    println '-------------------------------------------------------------'
+    println "BackupVersion: ${plugin.getBackupVersion()}"
+    println "Dependents: ${plugin.getDependents()}"
+    println "Dependencies: ${plugin.getDependencies()}"
+    println "RequiredCoreVersion: ${plugin.getRequiredCoreVersion()}"
+    println "Version: ${plugin.getVersion()}"
+    println "VersionNumber: ${plugin.getVersionNumber()}"
+    println "DerivedDependencyErrors: ${plugin.getDerivedDependencyErrors()}"
+    println ''
+  }
+}
+
+/**
+ * Prints information about packages loaded by each plugin installed on the Jenkins server
+ */
+def printClassLoaderInformationForPlugins() {
+  println 'Looking for Plugins Class Loader Information'
+  println '############################################################'
+  println ''
+  Jenkins.instance.pluginManager.activePlugins.forEach { PluginWrapper plugin ->
+    println "Found ${plugin}"
+    println '-------------------------------------------------------------'
+    println "Packages: ${plugin.classLoader.getPackages()}"
+    println "Parent: ${plugin.classLoader.getParent()}"
+    println ''
+  }
+}
+
+return

--- a/support/print-plugins-information-script.groovy
+++ b/support/print-plugins-information-script.groovy
@@ -1,3 +1,16 @@
+/*
+ * Copyright (c) 2016-present Sonatype, Inc. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+
 /**
  * This script is intended for support purposes only. The script do not get any sensitive information, it only gets
  * information about the installed plugins on the Jenkins server, the packages loaded by each plugin, and information
@@ -22,11 +35,11 @@ printClassLoaderInformationForPlugins()
  */
 def printPluginsLoadingClasses() {
   println 'Looking for Plugins Loading Classes'
-  println '############################################################'
+  println('#' * 80)
   println ''
   def classesToFind = [
-      "com.sun.org.apache.xerces.internal.jaxp.DocumentBuilderFactoryImpl",
-      "org.cyclonedx.generators.xml.AbstractBomXmlGenerator",
+      'com.sun.org.apache.xerces.internal.jaxp.DocumentBuilderFactoryImpl',
+      'org.cyclonedx.generators.xml.AbstractBomXmlGenerator',
   ]
   for (className in classesToFind) {
     printPluginsLoadingClass(className)
@@ -36,7 +49,7 @@ def printPluginsLoadingClasses() {
 def printPluginsLoadingClass(className) {
   def clazzResource = className.replaceAll("\\.", "/") + ".class"
   println "Looking for: ${clazzResource}"
-  println '-------------------------------------------------------------'
+  println('-' * 80)
   def list = []
   Jenkins.instance.pluginManager.activePlugins.forEach { PluginWrapper plugin ->
     def c = plugin.classLoader.getResources(clazzResource)
@@ -53,19 +66,20 @@ def printPluginsLoadingClass(className) {
  */
 def printPluginsInformation() {
   println 'Looking for Plugins Information'
-  println '############################################################'
+  println('#' * 80)
   println ''
   Jenkins.instance.pluginManager.activePlugins.forEach { PluginWrapper plugin ->
     println "Found: ${plugin}"
-    println '-------------------------------------------------------------'
-    println "BackupVersion: ${plugin.getBackupVersion()}"
-    println "Dependents: ${plugin.getDependents()}"
-    println "Dependencies: ${plugin.getDependencies()}"
-    println "RequiredCoreVersion: ${plugin.getRequiredCoreVersion()}"
-    println "Version: ${plugin.getVersion()}"
-    println "VersionNumber: ${plugin.getVersionNumber()}"
-    println "DerivedDependencyErrors: ${plugin.getDerivedDependencyErrors()}"
-    println ''
+    println('-' * 80)
+    println """
+        BackupVersion: ${plugin.getBackupVersion()}
+        Dependents: ${plugin.getDependents()}
+        Dependencies: ${plugin.getDependencies()}
+        RequiredCoreVersion: ${plugin.getRequiredCoreVersion()}
+        Version: ${plugin.getVersion()}
+        VersionNumber: ${plugin.getVersionNumber()}
+        DerivedDependencyErrors: ${plugin.getDerivedDependencyErrors()}\n
+    """.stripIndent()
   }
 }
 
@@ -74,15 +88,16 @@ def printPluginsInformation() {
  */
 def printClassLoaderInformationForPlugins() {
   println 'Looking for Plugins Class Loader Information'
-  println '############################################################'
+  println('#' * 80)
   println ''
   Jenkins.instance.pluginManager.activePlugins.forEach { PluginWrapper plugin ->
     println "Found ${plugin}"
-    println '-------------------------------------------------------------'
-    println "Packages: ${plugin.classLoader.getPackages()}"
-    println "Classloader: ${plugin.classLoader}"
-    println "Parent Classloader: ${plugin.classLoader.getParent()}"    
-    println ''
+    println('-' * 80)
+    println """
+        Packages: ${plugin.classLoader.getPackages()}
+        Classloader: ${plugin.classLoader}
+        Parent Classloader: ${plugin.classLoader.getParent()}\n
+    """.stripIndent()
   }
 }
 

--- a/support/print-plugins-information-script.groovy
+++ b/support/print-plugins-information-script.groovy
@@ -80,7 +80,8 @@ def printClassLoaderInformationForPlugins() {
     println "Found ${plugin}"
     println '-------------------------------------------------------------'
     println "Packages: ${plugin.classLoader.getPackages()}"
-    println "Parent: ${plugin.classLoader.getParent()}"
+    println "Classloader: ${plugin.classLoader}"
+    println "Parent Classloader: ${plugin.classLoader.getParent()}"    
     println ''
   }
 }


### PR DESCRIPTION
Adding a script to get information about the plugins installed on the Jenkins server. It gets information about the plugins, the loaded packages by each plugin, and how Jenkins is loading some classes.

As we haven't been able to reproduce the issue reported on the JIRA ticket, we are creating this script to try to get a picture of the customer's Jenkins server to try to reproduce the issue locally.

JIRA: https://issues.sonatype.org/browse/INT-6741
Build: https://jenkins.ci.sonatype.dev/job/integrations/job/jenkins/job/feature-snapshots/job/INT-6741-support-script-to-get-plugin-details/