### PR TITLE
Check compatibility with jenkins 2.346.1 - INT-6925

### DIFF
--- a/Jenkinsfile.sonatype.extra-tests
+++ b/Jenkinsfile.sonatype.extra-tests
@@ -33,7 +33,7 @@ pipeline {
   stages {
     stage('Parallel Test Groups') {
       parallel {
-        stage('Tests - Java 8 - Jenkins 2.249.1') {
+        stage('Jenkins 2.249.1 - Java 8') {
           agent { label agentLabel }
           steps {
             runTests('Java 8')
@@ -44,7 +44,7 @@ pipeline {
             }
           }
         }
-        stage('Tests - Java 11 - Jenkins 2.346.1') {
+        stage('Jenkins 2.346.1 - Java 11') {
           agent { label agentLabel }
           steps {
             runTests('OpenJDK 11',

--- a/Jenkinsfile.sonatype.extra-tests
+++ b/Jenkinsfile.sonatype.extra-tests
@@ -7,13 +7,13 @@
 
 String agentLabel = 'ubuntu-zion'
 
-def runTests(String javaVersion = 'Java 8') {
+def runTests(String javaVersion = 'Java 8', String mavenExtra = '') {
   def config = mavenCommon(
       javaVersion: javaVersion,
       mavenVersion: 'Maven 3.6.x',
       useEventSpy: false
   )
-  mvn config, 'clean install'
+  mvn config, "clean install ${mavenExtra}"
 }
 
 def captureResultsAndCleanup() {
@@ -33,7 +33,7 @@ pipeline {
   stages {
     stage('Parallel Test Groups') {
       parallel {
-        stage('Unit and Integration Tests - Java8') {
+        stage('Tests - Java 8 - Jenkins 2.249.1') {
           agent { label agentLabel }
           steps {
             runTests('Java 8')
@@ -44,10 +44,11 @@ pipeline {
             }
           }
         }
-        stage('Unit and Integration Tests - Java11') {
+        stage('Tests - Java 11 - Jenkins 2.346.1') {
           agent { label agentLabel }
           steps {
-            runTests('OpenJDK 11')
+            runTests('OpenJDK 11',
+                '-Djenkins.version=2.346.1 -Djenkins.tools.bom.artifactId=bom-2.346.x -Djenkins.tools.bom.version=1461.vb_3c6de28f2b_a_')
           }
           post {
             always {

--- a/pom.xml
+++ b/pom.xml
@@ -63,8 +63,14 @@
     <revision>3.14</revision>
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/nexus-platform-plugin</gitHubRepo>
+
     <!-- This is the minimum advertised compatible version -->
     <jenkins.version>2.249.1</jenkins.version>
+
+    <!-- See: https://github.com/jenkinsci/bom -->
+    <jenkins.tools.bom.artifactId>bom-2.249.x</jenkins.tools.bom.artifactId>
+    <jenkins.tools.bom.version>984.vb5eaac999a7e</jenkins.tools.bom.version>
+
     <enforcer.skip>true</enforcer.skip> <!-- TODO numerous requireUpperBoundDeps, some probably indicative of real problems -->
     <jvnet-localizer-plugin.version>1.23</jvnet-localizer-plugin.version>
     <forkCount>1</forkCount>
@@ -98,8 +104,8 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.249.x</artifactId>
-        <version>984.vb5eaac999a7e</version>
+        <artifactId>${jenkins.tools.bom.artifactId}</artifactId>
+        <version>${jenkins.tools.bom.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/src/main/java/org/sonatype/nexus/ci/iq/IqClientFactory.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/iq/IqClientFactory.groovy
@@ -119,7 +119,7 @@ class IqClientFactory
   }
 
   private static String getPluginVersion() {
-    def pluginWrapper = Jenkins.instance?.pluginManager?.getPlugin('nexus-jenkins-plugin')
+    def pluginWrapper = Jenkins.getInstanceOrNull()?.pluginManager?.getPlugin('nexus-jenkins-plugin')
     if (pluginWrapper) {
       def  version = pluginWrapper.version
       int index = version.indexOf(' ')

--- a/src/test/java/org/sonatype/nexus/ci/iq/IqClientFactoryTest.groovy
+++ b/src/test/java/org/sonatype/nexus/ci/iq/IqClientFactoryTest.groovy
@@ -338,6 +338,8 @@ class IqClientFactoryTest
       def iqClientBuilder = Mock(InternalIqClientBuilder)
       InternalIqClientBuilder.create() >> iqClientBuilder
 
+      def jenkinsVersion = System.getProperty('jenkins.version')?:'2.249.1'
+
     when:
       IqClientFactory.getIqClient(
           new IqClientFactoryConfiguration(credentialsId: credentialsId, serverUrl: URI.create(url)))
@@ -346,7 +348,7 @@ class IqClientFactoryTest
       1 * iqClientBuilder.withServerConfig(_) >> iqClientBuilder
       1 * iqClientBuilder.withProxyConfig(_) >> iqClientBuilder
       1 * iqClientBuilder.withUserAgent(
-          allOf(startsWith('Sonatype_CLM_CI_Jenkins/'), endsWith('Jenkins 2.249.1)'))) >> iqClientBuilder
+          allOf(startsWith('Sonatype_CLM_CI_Jenkins/'), endsWith("Jenkins ${jenkinsVersion})"))) >> iqClientBuilder
       1 * iqClientBuilder.withLogger(_) >> iqClientBuilder
   }
 }

--- a/src/test/resources/org/sonatype/nexus/ci/quality/RuleSetAll.groovy
+++ b/src/test/resources/org/sonatype/nexus/ci/quality/RuleSetAll.groovy
@@ -12,8 +12,6 @@
  */
 package org.sonatype.nexus.ci.quality
 
-import jnr.posix.util.MethodName
-import org.gmetrics.metric.abc.AbcMetric
 import org.gmetrics.metric.crap.CrapMetric
 
 ruleset {


### PR DESCRIPTION
#### Description
The purpose of this PR is to make sure the plugin is compatible with Jenkins 2.346.1. 

To achieve that I modified the project and CI setup to run all our tests against this version as well. Before we tested only against the minimum supported version. Going forward we're going to test against the minimum supported and the latest released versions.

#### Links
Jira: https://issues.sonatype.org/browse/INT-6925
Build: https://jenkins.ci.sonatype.dev/job/integrations/job/jenkins/job/feature-snapshots/job/INT-6925_Check_compatibility_with_Jenkins_2.346.1/