### PR TITLE
INT-7002 Check compatibility with Jenkins 2.346.2

### DIFF
--- a/Jenkinsfile.sonatype.extra-tests
+++ b/Jenkinsfile.sonatype.extra-tests
@@ -44,11 +44,11 @@ pipeline {
             }
           }
         }
-        stage('Jenkins 2.346.1 - Java 11') {
+        stage('Jenkins 2.346.2 - Java 11') {
           agent { label agentLabel }
           steps {
             runTests('OpenJDK 11',
-                '-Djenkins.version=2.346.1 -Djenkins.tools.bom.artifactId=bom-2.346.x -Djenkins.tools.bom.version=1461.vb_3c6de28f2b_a_')
+                '-Djenkins.version=2.346.2 -Djenkins.tools.bom.artifactId=bom-2.346.x -Djenkins.tools.bom.version=1508.v4b_d09ff0e893')
           }
           post {
             always {


### PR DESCRIPTION
Adding tests for Jenkins  2.346.2

Jira: https://issues.sonatype.org/browse/INT-7002
Build: https://jenkins.ci.sonatype.dev/job/integrations/job/jenkins/job/feature-snapshots/job/INT-7002-check-compatibility-with-jenkins-2.346.2/