### PR TITLE
INT-7157 add org id parameter to nexus IQ policy evaluation pipeline syntax

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
   </developers>
 
   <properties>
-    <revision>3.15</revision>
+    <revision>3.16</revision>
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/nexus-platform-plugin</gitHubRepo>
 

--- a/src/main/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluator.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluator.groovy
@@ -20,6 +20,8 @@ interface IqPolicyEvaluator
 
   String getIqStage()
 
+  String getIqOrganization()
+
   IqApplication getIqApplication()
 
   List<ScanPattern> getIqScanPatterns()

--- a/src/main/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorBuildStep.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorBuildStep.groovy
@@ -177,5 +177,10 @@ class IqPolicyEvaluatorBuildStep
       IqUtil.
           verifyJobCredentials(nxiqConfiguration?.serverUrl, jobCredentialsId ?: nxiqConfiguration?.credentialsId, job)
     }
+
+    @Override
+    FormValidation doCheckIqOrganization(@QueryParameter String value) {
+      FormValidation.ok()
+    }
   }
 }

--- a/src/main/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorBuildStep.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorBuildStep.groovy
@@ -40,6 +40,8 @@ class IqPolicyEvaluatorBuildStep
 
   String iqStage
 
+  String iqOrganization
+
   IqApplication iqApplication
 
   List<ScanPattern> iqScanPatterns
@@ -58,6 +60,7 @@ class IqPolicyEvaluatorBuildStep
   @SuppressWarnings('ParameterCount')
   IqPolicyEvaluatorBuildStep(final String iqInstanceId,
                              final String iqStage,
+                             final String iqOrganization,
                              final IqApplication iqApplication,
                              final List<ScanPattern> iqScanPatterns,
                              final List<ModuleExclude> iqModuleExcludes,
@@ -72,6 +75,7 @@ class IqPolicyEvaluatorBuildStep
     this.iqScanPatterns = iqScanPatterns
     this.iqModuleExcludes = iqModuleExcludes
     this.iqStage = iqStage
+    this.iqOrganization = iqOrganization
     this.iqApplication = iqApplication
     this.advancedProperties = advancedProperties
     this.enableDebugLogging = enableDebugLogging

--- a/src/main/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorDescriptor.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorDescriptor.groovy
@@ -39,4 +39,6 @@ interface IqPolicyEvaluatorDescriptor
   FormValidation doCheckEnableDebugLogging(String value)
 
   FormValidation doVerifyCredentials(String iqInstanceId, String jobCredentialsId, Job job)
+
+  FormValidation doCheckIqOrganization(String iqOrganization)
 }

--- a/src/main/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorUtil.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorUtil.groovy
@@ -72,7 +72,7 @@ class IqPolicyEvaluatorUtil
           log: loggerBridge))
 
       iqClient.validateServerVersion(MINIMAL_SERVER_VERSION_REQUIRED)
-      def verified = iqClient.verifyOrCreateApplication(applicationId)
+      def verified = iqClient.verifyOrCreateApplication(applicationId, iqPolicyEvaluator.iqOrganization)
       checkArgument(verified, 'The application ID ' + applicationId + ' is invalid.')
 
       def expandedScanPatterns = getScanPatterns(iqPolicyEvaluator.iqScanPatterns, envVars)

--- a/src/main/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorWorkflowStep.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorWorkflowStep.groovy
@@ -53,6 +53,11 @@ class IqPolicyEvaluatorWorkflowStep
   String advancedProperties
 
   @DataBoundSetter
+  void setIqOrganization(final String iqOrganization) {
+    this.iqOrganization = iqOrganization
+  }
+
+  @DataBoundSetter
   void setIqScanPatterns(final List<ScanPattern> iqScanPatterns) {
     this.iqScanPatterns = iqScanPatterns
   }

--- a/src/main/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorWorkflowStep.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorWorkflowStep.groovy
@@ -36,6 +36,8 @@ class IqPolicyEvaluatorWorkflowStep
 
   String iqStage
 
+  String iqOrganization
+
   IqApplication iqApplication
 
   List<ScanPattern> iqScanPatterns

--- a/src/main/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorWorkflowStep.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorWorkflowStep.groovy
@@ -199,5 +199,10 @@ class IqPolicyEvaluatorWorkflowStep
       IqUtil.
           verifyJobCredentials(nxiqConfiguration?.serverUrl, jobCredentialsId ?: nxiqConfiguration?.credentialsId, job)
     }
+
+    @Override
+    FormValidation doCheckIqOrganization(@QueryParameter String value) {
+      FormValidation.ok()
+    }
   }
 }

--- a/src/main/resources/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorBuildStep/config.groovy
+++ b/src/main/resources/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorBuildStep/config.groovy
@@ -55,8 +55,8 @@ f.section(title: descriptor.displayName) {
     f.select()
   }
 
-  f.entry(title: _(Messages.IqPolicyEvaluation_Stage()), field: 'iqOrganization') {
-    f.select()
+  f.entry(title: _(Messages.IqPolicyEvaluation_Organization()), field: 'iqOrganization') {
+    f.textbox()
   }
 
   f.entry(title: 'Application') {

--- a/src/main/resources/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorBuildStep/config.groovy
+++ b/src/main/resources/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorBuildStep/config.groovy
@@ -55,6 +55,10 @@ f.section(title: descriptor.displayName) {
     f.select()
   }
 
+  f.entry(title: _(Messages.IqPolicyEvaluation_Stage()), field: 'iqOrganization') {
+    f.select()
+  }
+
   f.entry(title: 'Application') {
     f.hetero_radio(field: 'iqApplication', descriptors: Jenkins.instance.getDescriptorList(IqApplication.class))
   }

--- a/src/main/resources/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorBuildStep/help-iqOrganization.html
+++ b/src/main/resources/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorBuildStep/help-iqOrganization.html
@@ -1,0 +1,19 @@
+<!--
+
+    Copyright (c) 2016-present Sonatype, Inc. All rights reserved.
+
+    This program is licensed to you under the Apache License Version 2.0,
+    and you may not use this file except in compliance with the Apache License Version 2.0.
+    You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the Apache License Version 2.0 is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+
+-->
+<div>
+  Specify the IQ Organization ID. Determines the organization under which the application will be created
+  in case the application doesn't exist and the automatic application creation configuration is enabled
+  by the organization ID.
+</div>

--- a/src/main/resources/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorBuildStep/help-iqOrganization.html
+++ b/src/main/resources/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorBuildStep/help-iqOrganization.html
@@ -14,6 +14,5 @@
 -->
 <div>
   Specify the IQ Organization ID. Determines the organization under which the application will be created
-  in case the application doesn't exist and the automatic application creation configuration is enabled
-  by the organization ID.
+  in case the application doesn't exist and the automatic application creation configuration is enabled.
 </div>

--- a/src/main/resources/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorWorkflowStep/config.groovy
+++ b/src/main/resources/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorWorkflowStep/config.groovy
@@ -56,7 +56,7 @@ f.section(title: descriptor.displayName) {
   }
 
   f.entry(title: _(Messages.IqPolicyEvaluation_Organization()), field: 'iqOrganization') {
-    f.select()
+    f.textbox()
   }
 
   f.entry(title: 'Application') {

--- a/src/main/resources/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorWorkflowStep/config.groovy
+++ b/src/main/resources/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorWorkflowStep/config.groovy
@@ -55,6 +55,10 @@ f.section(title: descriptor.displayName) {
     f.select()
   }
 
+  f.entry(title: _(Messages.IqPolicyEvaluation_Organization()), field: 'iqOrganization') {
+    f.select()
+  }
+
   f.entry(title: 'Application') {
     f.hetero_radio(field: 'iqApplication', descriptors: Jenkins.instance.getDescriptorList(IqApplication.class))
   }

--- a/src/main/resources/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorWorkflowStep/help-iqOrganization.html
+++ b/src/main/resources/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorWorkflowStep/help-iqOrganization.html
@@ -1,0 +1,19 @@
+<!--
+
+    Copyright (c) 2016-present Sonatype, Inc. All rights reserved.
+
+    This program is licensed to you under the Apache License Version 2.0,
+    and you may not use this file except in compliance with the Apache License Version 2.0.
+    You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the Apache License Version 2.0 is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+
+-->
+<div>
+  Specify the IQ Organization ID. Determines the organization under which the application will be created
+  in case the application doesn't exist and the automatic application creation configuration is enabled
+  by the organization ID.
+</div>

--- a/src/main/resources/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorWorkflowStep/help-iqOrganization.html
+++ b/src/main/resources/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorWorkflowStep/help-iqOrganization.html
@@ -14,6 +14,5 @@
 -->
 <div>
   Specify the IQ Organization ID. Determines the organization under which the application will be created
-  in case the application doesn't exist and the automatic application creation configuration is enabled
-  by the organization ID.
+  in case the application doesn't exist and the automatic application creation configuration is enabled.
 </div>

--- a/src/main/resources/org/sonatype/nexus/ci/iq/Messages.properties
+++ b/src/main/resources/org/sonatype/nexus/ci/iq/Messages.properties
@@ -20,6 +20,7 @@ IqPolicyEvaluation.Evaluating=Running Nexus Policy Evaluation
 
 IqPolicyEvaluation.AddIqServers=Add IQ Servers via:
 IqPolicyEvaluation.Stage=Stage
+IqPolicyEvaluation.Organization=Organization
 IqPolicyEvaluation.Application=Application
 IqPolicyEvaluation.ManualApplication=Specify an IQ Application
 IqPolicyEvaluation.SelectApplication=Select an IQ Application

--- a/src/test/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorDescriptorTest.groovy
+++ b/src/test/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorDescriptorTest.groovy
@@ -139,6 +139,26 @@ abstract class IqPolicyEvaluatorDescriptorTest
       'applicationId' | Kind.OK    | '<div/>'
   }
 
+  def 'it validates that organization id is not required'() {
+    setup:
+      def descriptor = getDescriptor()
+
+    when:
+      "validating organization Id $organization"
+      def validation = descriptor.doCheckIqOrganization(organization)
+
+    then:
+      "it returns $kind with message $message"
+      validation.kind == kind
+      validation.renderHtml() == message
+
+    where:
+      organization | kind    | message
+      ''           | Kind.OK | '<div/>'
+      null         | Kind.OK | '<div/>'
+      'org-id'     | Kind.OK | '<div/>'
+  }
+
   def 'it validates that scan pattern is not required'() {
     setup:
       def descriptor = getDescriptor()
@@ -197,8 +217,6 @@ abstract class IqPolicyEvaluatorDescriptorTest
       null    | Kind.OK | '<div/>'
       'file'  | Kind.OK | '<div/>'
   }
-
-
 
   def 'it validates that application items are filled'() {
     setup:

--- a/src/test/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorDescriptorTest.groovy
+++ b/src/test/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorDescriptorTest.groovy
@@ -351,7 +351,7 @@ abstract class IqPolicyEvaluatorDescriptorTest
       GroovyMock(NxiqConfiguration, global: true)
 
     when:
-      def buildStep = new IqPolicyEvaluatorBuildStep(null, null, null, null, null, null, 'jobSpecificCredentialsId',
+      def buildStep = new IqPolicyEvaluatorBuildStep(null, null, null, null, null, null, null, 'jobSpecificCredentialsId',
           null, null)
 
     then:

--- a/src/test/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorIntegrationTest.groovy
+++ b/src/test/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorIntegrationTest.groovy
@@ -93,7 +93,7 @@ class IqPolicyEvaluatorIntegrationTest
       def build = project.scheduleBuild2(0).get()
 
     then: 'the application is scanned and evaluated'
-      1 * iqClient.verifyOrCreateApplication(*_, null) >> true
+      1 * iqClient.verifyOrCreateApplication(*_) >> true
       1 * iqClient.scan(*_) >> new ScanResult(new Scan(), File.createTempFile('dummy-scan', '.xml.gz'))
       1 * iqClient.evaluateApplication(*_) >>
           new ApplicationPolicyEvaluation(0, 1, 2, 3, 11, 12, 13, 0, 1, [createAlert(Action.ID_NOTIFY)],
@@ -129,7 +129,7 @@ class IqPolicyEvaluatorIntegrationTest
       def build = project.scheduleBuild2(0).get()
 
     then: 'the application is scanned and evaluated'
-      1 * iqClient.verifyOrCreateApplication(*_, null) >> true
+      1 * iqClient.verifyOrCreateApplication(*_) >> true
       1 * iqClient.scan(*_) >> new ScanResult(new Scan(), File.createTempFile('dummy-scan', '.xml.gz'))
       1 * iqClient.evaluateApplication(*_) >>
               new ApplicationPolicyEvaluation(0, 1, 2, 3, 11, 12, 13, 0, 1, [createAlert(Action.ID_NOTIFY)],
@@ -162,7 +162,7 @@ class IqPolicyEvaluatorIntegrationTest
       def build = project.scheduleBuild2(0).get()
 
     then: 'the application is scanned and evaluated'
-      1 * iqClient.verifyOrCreateApplication(*_, null) >> true
+      1 * iqClient.verifyOrCreateApplication(*_) >> true
       1 * iqClient.scan(_, _,
           {
             it.size() == 1 && it.containsKey('excludedFiles') && it.get('excludedFiles') == 'target/my-project.jar'
@@ -229,7 +229,7 @@ class IqPolicyEvaluatorIntegrationTest
       def build = project.scheduleBuild2(0).get()
 
     then: 'the application is scanned and evaluated'
-      1 * iqClient.verifyOrCreateApplication(*_, null) >> true
+      1 * iqClient.verifyOrCreateApplication(*_) >> true
       1 * iqClient.scan(*_) >> new ScanResult(new Scan(), File.createTempFile('dummy-scan', '.xml.gz'))
       1 * iqClient.evaluateApplication(*_) >> new ApplicationPolicyEvaluation(0, 1, 2, 3, 11, 12, 13, 0, 1, [],
           'http://server/link/to/report')
@@ -258,7 +258,7 @@ class IqPolicyEvaluatorIntegrationTest
       def build = project.scheduleBuild2(0).get()
 
     then: 'the application is scanned and evaluated'
-      1 * iqClient.verifyOrCreateApplication(*_, null) >> true
+      1 * iqClient.verifyOrCreateApplication(*_) >> true
       1 * iqClient.scan(*_) >> new ScanResult(new Scan(), File.createTempFile('dummy-scan', '.xml.gz'))
       1 * iqClient.evaluateApplication(*_) >> new ApplicationPolicyEvaluation(0, 1, 2, 3, 11, 12, 13, 0, 1, [],
           'http://server/link/to/report')
@@ -283,7 +283,7 @@ class IqPolicyEvaluatorIntegrationTest
       def build = project.scheduleBuild2(0).get()
 
     then: 'the application is scanned and evaluated'
-      1 * iqClient.verifyOrCreateApplication(*_, null) >> true
+      1 * iqClient.verifyOrCreateApplication(*_) >> true
       1 * iqClient.scan(*_) >> new ScanResult(new Scan(), File.createTempFile('dummy-scan', '.xml.gz'))
       1 * iqClient.evaluateApplication(*_) >> new ApplicationPolicyEvaluation(0, 1, 2, 3, 11, 12, 13, 0, 1, [],
               'http://server/link/to/report')
@@ -308,7 +308,7 @@ class IqPolicyEvaluatorIntegrationTest
       def build = project.scheduleBuild2(0).get()
 
     then: 'an exception is thrown when getting proprietary config from IQ server'
-      1 * iqClient.verifyOrCreateApplication(*_, null) >> true
+      1 * iqClient.verifyOrCreateApplication(*_) >> true
       1 * iqClient.getProprietaryConfigForApplicationEvaluation('app') >> {
         throw new IqClientException("ERROR", new IOException("BANG!"))
       }
@@ -336,7 +336,7 @@ class IqPolicyEvaluatorIntegrationTest
       def build = project.scheduleBuild2(0).get()
 
     then: 'an exception is thrown when getting proprietary config from IQ server'
-      1 * iqClient.verifyOrCreateApplication(*_, null) >> true
+      1 * iqClient.verifyOrCreateApplication(*_) >> true
       1 * iqClient.getProprietaryConfigForApplicationEvaluation('app') >> {
         throw new IqClientException("ERROR", new IOException("BANG!"))
       }
@@ -358,7 +358,7 @@ class IqPolicyEvaluatorIntegrationTest
       def build = project.scheduleBuild2(0).get()
 
     then: 'an exception is thrown when getting proprietary config from IQ server'
-      1 * iqClient.verifyOrCreateApplication(*_, null) >> true
+      1 * iqClient.verifyOrCreateApplication(*_) >> true
       1 * iqClient.getProprietaryConfigForApplicationEvaluation('app') >> {
         throw new IqClientException("ERROR", new IOException("BANG!"))
       }
@@ -380,7 +380,7 @@ class IqPolicyEvaluatorIntegrationTest
       def build = project.scheduleBuild2(0).get()
 
     then: 'an exception is thrown when getting proprietary config from IQ server'
-      1 * iqClient.verifyOrCreateApplication(*_, null) >> true
+      1 * iqClient.verifyOrCreateApplication(*_) >> true
       1 * iqClient.getProprietaryConfigForApplicationEvaluation('app') >> {
         throw new IqClientException("ERROR", new IOException("BANG!"))
       }
@@ -405,7 +405,7 @@ class IqPolicyEvaluatorIntegrationTest
       def build = project.scheduleBuild2(0).get()
 
     then: 'an exception is thrown when getting proprietary config from IQ server'
-      1 * iqClient.verifyOrCreateApplication(*_, null) >> true
+      1 * iqClient.verifyOrCreateApplication(*_) >> true
       1 * iqClient.getProprietaryConfigForApplicationEvaluation('app') >> { throw exception }
 
     then: 'the build fails'
@@ -429,7 +429,7 @@ class IqPolicyEvaluatorIntegrationTest
       def build = project.scheduleBuild2(0).get()
 
     then: 'an exception is thrown when getting proprietary config from IQ server'
-      1 * iqClient.verifyOrCreateApplication(*_, null) >> true
+      1 * iqClient.verifyOrCreateApplication(*_) >> true
       1 * iqClient.getProprietaryConfigForApplicationEvaluation('app') >> { throw exception }
 
     then: 'the return code is successful'
@@ -456,7 +456,7 @@ class IqPolicyEvaluatorIntegrationTest
       def build = project.scheduleBuild2(0).get()
 
     then: 'the application is scanned and evaluated'
-      1 * iqClient.verifyOrCreateApplication(*_, null) >> true
+      1 * iqClient.verifyOrCreateApplication(*_) >> true
       1 * iqClient.scan(*_) >> new ScanResult(new Scan(), File.createTempFile('dummy-scan', '.xml.gz'))
       1 * iqClient.evaluateApplication(*_) >> new ApplicationPolicyEvaluation(0, 1, 2, 3, 11, 12, 13, 0, 1,
           [createAlert(Action.ID_FAIL)], 'http://server/link/to/report')
@@ -494,7 +494,7 @@ class IqPolicyEvaluatorIntegrationTest
       def build = project.scheduleBuild2(0).get()
 
     then: 'the application is scanned and evaluated'
-      1 * iqClient.verifyOrCreateApplication(*_, null) >> true
+      1 * iqClient.verifyOrCreateApplication(*_) >> true
       1 * iqClient.scan(*_) >> new ScanResult(new Scan(), File.createTempFile('dummy-scan', '.xml.gz'))
       1 * iqClient.evaluateApplication(*_) >> new ApplicationPolicyEvaluation(0, 1, 2, 3, 11, 12, 13, 0, 1,
           [createAlert(Action.ID_FAIL)], 'http://server/link/to/report')
@@ -523,7 +523,7 @@ class IqPolicyEvaluatorIntegrationTest
       def build = project.scheduleBuild2(0).get()
 
     then: 'the application is scanned and evaluated'
-      1 * iqClient.verifyOrCreateApplication(*_, null) >> true
+      1 * iqClient.verifyOrCreateApplication(*_) >> true
       1 * iqClient.scan(*_) >> new ScanResult(new Scan(), File.createTempFile('dummy-scan', '.xml.gz'))
       1 * iqClient.evaluateApplication(*_) >> new ApplicationPolicyEvaluation(0, 1, 2, 3, 11, 12, 13, 0, 1,
           [createAlert(Action.ID_FAIL)], 'http://server/link/to/report')
@@ -574,7 +574,7 @@ class IqPolicyEvaluatorIntegrationTest
       def build = project.scheduleBuild2(0).get()
 
     then: 'the application is scanned and evaluated'
-      1 * iqClient.verifyOrCreateApplication(*_, null) >> false
+      1 * iqClient.verifyOrCreateApplication(*_) >> false
 
     then: 'the build fails'
       jenkins.assertBuildStatus(Result.FAILURE, build)
@@ -614,7 +614,7 @@ class IqPolicyEvaluatorIntegrationTest
       def build = project.scheduleBuild2(0).get()
 
     then: 'the application is scanned and evaluated'
-      1 * iqClient.verifyOrCreateApplication(*_, null) >> false
+      1 * iqClient.verifyOrCreateApplication(*_) >> false
 
     and: 'the build fails'
       jenkins.assertBuildStatus(Result.FAILURE, build)
@@ -638,7 +638,7 @@ class IqPolicyEvaluatorIntegrationTest
       def build = project.scheduleBuild2(0).get()
 
     then: 'the application is evaluated and server version is checked'
-      1 * iqClient.validateServerVersion(*_, null) >> { throw new Exception("server version check failed") }
+      1 * iqClient.validateServerVersion(*_) >> { throw new Exception("server version check failed") }
 
     and: 'the build fails'
       jenkins.assertBuildStatus(Result.FAILURE, build)
@@ -711,7 +711,7 @@ class IqPolicyEvaluatorIntegrationTest
       def build = project.scheduleBuild2(0).get()
 
     then: 'the application is scanned and evaluated'
-      1 * iqClient.verifyOrCreateApplication(*_, null) >> true
+      1 * iqClient.verifyOrCreateApplication(*_) >> true
       1 * iqClient.scan(*_) >> new ScanResult(new Scan(), File.createTempFile('dummy-scan', '.xml.gz'))
       1 * iqClient.evaluateApplication(*_) >> new ApplicationPolicyEvaluation(0, 1, 2, 3, 11, 12, 13, 0, 1, [],
           'http://server/link/to/report')
@@ -735,7 +735,7 @@ class IqPolicyEvaluatorIntegrationTest
       def build = project.scheduleBuild2(0).get()
 
     then: 'the application is scanned and evaluated'
-      1 * iqClient.verifyOrCreateApplication(*_, null) >> true
+      1 * iqClient.verifyOrCreateApplication(*_) >> true
       1 * iqClient.scan(*_) >> new ScanResult(new Scan(), File.createTempFile('dummy-scan', '.xml.gz'))
       1 * iqClient.evaluateApplication(*_) >> new ApplicationPolicyEvaluation(0, 0, 0, 0, 0, 0, 0, 0, 0, [],
           'http://server/link/to/report')
@@ -757,7 +757,7 @@ class IqPolicyEvaluatorIntegrationTest
       def build = project.scheduleBuild2(0).get()
 
     then: 'the application is scanned and evaluated'
-      1 * iqClient.verifyOrCreateApplication(*_, null) >> true
+      1 * iqClient.verifyOrCreateApplication(*_) >> true
       1 * iqClient.scan(*_) >> new ScanResult(new Scan(), File.createTempFile('dummy-scan', '.xml.gz'))
       1 * iqClient.evaluateApplication(*_) >> new ApplicationPolicyEvaluation(0, 1, 2, 3, 11, 12, 13, 0, 1, [],
           'http://server/link/to/report')
@@ -887,7 +887,7 @@ class IqPolicyEvaluatorIntegrationTest
       def build = project.scheduleBuild2(0).get()
 
     then: 'the application is scanned and evaluated'
-      1 * iqClient.verifyOrCreateApplication(*_, null) >> true
+      1 * iqClient.verifyOrCreateApplication(*_) >> true
       1 * iqClient.scan(*_) >> new ScanResult(new Scan(), File.createTempFile('dummy-scan', '.xml.gz'))
       1 * iqClient.evaluateApplication(*_) >> new ApplicationPolicyEvaluation(0, 1, 2, 3, 11, 12, 13, 0, 1, [],
           'http://server/link/to/report')
@@ -911,7 +911,7 @@ class IqPolicyEvaluatorIntegrationTest
       def build = project.scheduleBuild2(0).get()
 
     then: 'the application is scanned and evaluated'
-      1 * iqClient.verifyOrCreateApplication(*_, null) >> true
+      1 * iqClient.verifyOrCreateApplication(*_) >> true
       1 * iqClient.scan(*_) >> new ScanResult(new Scan(), File.createTempFile('dummy-scan', '.xml.gz'))
       1 * iqClient.evaluateApplication(*_) >> new ApplicationPolicyEvaluation(0, 1, 2, 3, 11, 12, 13, 0, 1, [],
           'http://server/link/to/report')
@@ -934,7 +934,7 @@ class IqPolicyEvaluatorIntegrationTest
       def build = project.scheduleBuild2(0).get()
 
     then: 'the application is scanned and evaluated'
-      1 * iqClient.verifyOrCreateApplication(*_, null) >> true
+      1 * iqClient.verifyOrCreateApplication(*_) >> true
       1 * iqClient.scan(*_) >> new ScanResult(new Scan(), File.createTempFile('dummy-scan', '.xml.gz'))
       1 * iqClient.evaluateApplication(*_) >> new ApplicationPolicyEvaluation(0, 1, 2, 3, 11, 12, 13, 0, 1, [],
           'http://server/link/to/report')
@@ -957,7 +957,7 @@ class IqPolicyEvaluatorIntegrationTest
       def build = project.scheduleBuild2(0).get()
 
     then: 'the application is scanned and evaluated'
-      1 * iqClient.verifyOrCreateApplication(*_, null) >> true
+      1 * iqClient.verifyOrCreateApplication(*_) >> true
       1 * iqClient.scan(*_) >> new ScanResult(new Scan(), File.createTempFile('dummy-scan', '.xml.gz'))
       1 * iqClient.evaluateApplication(*_) >> new ApplicationPolicyEvaluation(0, 1, 2, 3, 11, 12, 13, 0, 1, [],
           'http://server/link/to/report')

--- a/src/test/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorIntegrationTest.groovy
+++ b/src/test/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorIntegrationTest.groovy
@@ -93,7 +93,7 @@ class IqPolicyEvaluatorIntegrationTest
       def build = project.scheduleBuild2(0).get()
 
     then: 'the application is scanned and evaluated'
-      1 * iqClient.verifyOrCreateApplication(*_) >> true
+      1 * iqClient.verifyOrCreateApplication(*_, null) >> true
       1 * iqClient.scan(*_) >> new ScanResult(new Scan(), File.createTempFile('dummy-scan', '.xml.gz'))
       1 * iqClient.evaluateApplication(*_) >>
           new ApplicationPolicyEvaluation(0, 1, 2, 3, 11, 12, 13, 0, 1, [createAlert(Action.ID_NOTIFY)],
@@ -129,7 +129,7 @@ class IqPolicyEvaluatorIntegrationTest
       def build = project.scheduleBuild2(0).get()
 
     then: 'the application is scanned and evaluated'
-      1 * iqClient.verifyOrCreateApplication(*_) >> true
+      1 * iqClient.verifyOrCreateApplication(*_, null) >> true
       1 * iqClient.scan(*_) >> new ScanResult(new Scan(), File.createTempFile('dummy-scan', '.xml.gz'))
       1 * iqClient.evaluateApplication(*_) >>
               new ApplicationPolicyEvaluation(0, 1, 2, 3, 11, 12, 13, 0, 1, [createAlert(Action.ID_NOTIFY)],
@@ -162,7 +162,7 @@ class IqPolicyEvaluatorIntegrationTest
       def build = project.scheduleBuild2(0).get()
 
     then: 'the application is scanned and evaluated'
-      1 * iqClient.verifyOrCreateApplication(*_) >> true
+      1 * iqClient.verifyOrCreateApplication(*_, null) >> true
       1 * iqClient.scan(_, _,
           {
             it.size() == 1 && it.containsKey('excludedFiles') && it.get('excludedFiles') == 'target/my-project.jar'
@@ -199,7 +199,7 @@ class IqPolicyEvaluatorIntegrationTest
       def build = project.scheduleBuild2(0).get()
 
     then: 'the application with application id "app" is scanned and evaluated'
-      1 * iqClient.verifyOrCreateApplication('app') >> true
+      1 * iqClient.verifyOrCreateApplication('app', null) >> true
       1 * iqClient.scan(*_) >> new ScanResult(new Scan(), File.createTempFile('dummy-scan', '.xml.gz'))
       1 * iqClient.evaluateApplication(*_) >>
           new ApplicationPolicyEvaluation(0, 1, 2, 3, 11, 12, 13, 0, 1, [], 'http://server/link/to/report')
@@ -229,7 +229,7 @@ class IqPolicyEvaluatorIntegrationTest
       def build = project.scheduleBuild2(0).get()
 
     then: 'the application is scanned and evaluated'
-      1 * iqClient.verifyOrCreateApplication(*_) >> true
+      1 * iqClient.verifyOrCreateApplication(*_, null) >> true
       1 * iqClient.scan(*_) >> new ScanResult(new Scan(), File.createTempFile('dummy-scan', '.xml.gz'))
       1 * iqClient.evaluateApplication(*_) >> new ApplicationPolicyEvaluation(0, 1, 2, 3, 11, 12, 13, 0, 1, [],
           'http://server/link/to/report')
@@ -250,7 +250,7 @@ class IqPolicyEvaluatorIntegrationTest
     given: 'a jenkins project'
       FreeStyleProject project = jenkins.createFreeStyleProject()
       project.buildersList.
-          add(new IqPolicyEvaluatorBuildStep(null, 'stage', new SelectedApplication('app'), [], [], false, 'cred-id',
+          add(new IqPolicyEvaluatorBuildStep(null, 'stage', null, new SelectedApplication('app'), [], [], false, 'cred-id',
               null, null))
       configureJenkins()
 
@@ -258,7 +258,7 @@ class IqPolicyEvaluatorIntegrationTest
       def build = project.scheduleBuild2(0).get()
 
     then: 'the application is scanned and evaluated'
-      1 * iqClient.verifyOrCreateApplication(*_) >> true
+      1 * iqClient.verifyOrCreateApplication(*_, null) >> true
       1 * iqClient.scan(*_) >> new ScanResult(new Scan(), File.createTempFile('dummy-scan', '.xml.gz'))
       1 * iqClient.evaluateApplication(*_) >> new ApplicationPolicyEvaluation(0, 1, 2, 3, 11, 12, 13, 0, 1, [],
           'http://server/link/to/report')
@@ -271,7 +271,7 @@ class IqPolicyEvaluatorIntegrationTest
     given: 'a jenkins project'
       FreeStyleProject project = jenkins.createFreeStyleProject()
       project.buildersList.
-              add(new IqPolicyEvaluatorBuildStep('id2', 'stage', new SelectedApplication('app'), [], [], false, 'cred-id',
+              add(new IqPolicyEvaluatorBuildStep('id2', 'stage', null, new SelectedApplication('app'), [], [], false, 'cred-id',
                       null, null))
       List<NxiqConfiguration> nxiqConfiguration = [
               new NxiqConfiguration('id1', 'int-id1', 'display-name1', 'http://server/url1', 'no-cred', false),
@@ -283,7 +283,7 @@ class IqPolicyEvaluatorIntegrationTest
       def build = project.scheduleBuild2(0).get()
 
     then: 'the application is scanned and evaluated'
-      1 * iqClient.verifyOrCreateApplication(*_) >> true
+      1 * iqClient.verifyOrCreateApplication(*_, null) >> true
       1 * iqClient.scan(*_) >> new ScanResult(new Scan(), File.createTempFile('dummy-scan', '.xml.gz'))
       1 * iqClient.evaluateApplication(*_) >> new ApplicationPolicyEvaluation(0, 1, 2, 3, 11, 12, 13, 0, 1, [],
               'http://server/link/to/report')
@@ -308,7 +308,7 @@ class IqPolicyEvaluatorIntegrationTest
       def build = project.scheduleBuild2(0).get()
 
     then: 'an exception is thrown when getting proprietary config from IQ server'
-      1 * iqClient.verifyOrCreateApplication(*_) >> true
+      1 * iqClient.verifyOrCreateApplication(*_, null) >> true
       1 * iqClient.getProprietaryConfigForApplicationEvaluation('app') >> {
         throw new IqClientException("ERROR", new IOException("BANG!"))
       }
@@ -336,7 +336,7 @@ class IqPolicyEvaluatorIntegrationTest
       def build = project.scheduleBuild2(0).get()
 
     then: 'an exception is thrown when getting proprietary config from IQ server'
-      1 * iqClient.verifyOrCreateApplication(*_) >> true
+      1 * iqClient.verifyOrCreateApplication(*_, null) >> true
       1 * iqClient.getProprietaryConfigForApplicationEvaluation('app') >> {
         throw new IqClientException("ERROR", new IOException("BANG!"))
       }
@@ -350,7 +350,7 @@ class IqPolicyEvaluatorIntegrationTest
     given: 'a jenkins project'
       def failBuildOnNetworkError = false
       FreeStyleProject project = jenkins.createFreeStyleProject()
-      project.buildersList.add(new IqPolicyEvaluatorBuildStep(null, 'stage', new SelectedApplication('app'), [], [],
+      project.buildersList.add(new IqPolicyEvaluatorBuildStep(null, 'stage', null, new SelectedApplication('app'), [], [],
           failBuildOnNetworkError, 'cred-id', null, null))
       configureJenkins()
 
@@ -358,7 +358,7 @@ class IqPolicyEvaluatorIntegrationTest
       def build = project.scheduleBuild2(0).get()
 
     then: 'an exception is thrown when getting proprietary config from IQ server'
-      1 * iqClient.verifyOrCreateApplication(*_) >> true
+      1 * iqClient.verifyOrCreateApplication(*_, null) >> true
       1 * iqClient.getProprietaryConfigForApplicationEvaluation('app') >> {
         throw new IqClientException("ERROR", new IOException("BANG!"))
       }
@@ -372,7 +372,7 @@ class IqPolicyEvaluatorIntegrationTest
     given: 'a jenkins project'
       FreeStyleProject project = jenkins.createFreeStyleProject()
       project.buildersList.
-          add(new IqPolicyEvaluatorBuildStep(null, 'stage', new SelectedApplication('app'), [], [], true, 'cred-id',
+          add(new IqPolicyEvaluatorBuildStep(null, 'stage', null, new SelectedApplication('app'), [], [], true, 'cred-id',
               null, null))
       configureJenkins()
 
@@ -380,7 +380,7 @@ class IqPolicyEvaluatorIntegrationTest
       def build = project.scheduleBuild2(0).get()
 
     then: 'an exception is thrown when getting proprietary config from IQ server'
-      1 * iqClient.verifyOrCreateApplication(*_) >> true
+      1 * iqClient.verifyOrCreateApplication(*_, null) >> true
       1 * iqClient.getProprietaryConfigForApplicationEvaluation('app') >> {
         throw new IqClientException("ERROR", new IOException("BANG!"))
       }
@@ -405,7 +405,7 @@ class IqPolicyEvaluatorIntegrationTest
       def build = project.scheduleBuild2(0).get()
 
     then: 'an exception is thrown when getting proprietary config from IQ server'
-      1 * iqClient.verifyOrCreateApplication(*_) >> true
+      1 * iqClient.verifyOrCreateApplication(*_, null) >> true
       1 * iqClient.getProprietaryConfigForApplicationEvaluation('app') >> { throw exception }
 
     then: 'the build fails'
@@ -421,7 +421,7 @@ class IqPolicyEvaluatorIntegrationTest
     given: 'a jenkins project'
       def failBuildOnNetworkError = false
       FreeStyleProject project = jenkins.createFreeStyleProject()
-      project.buildersList.add(new IqPolicyEvaluatorBuildStep(null, 'stage', new SelectedApplication('app'), [], [],
+      project.buildersList.add(new IqPolicyEvaluatorBuildStep(null, 'stage', null, new SelectedApplication('app'), [], [],
           failBuildOnNetworkError, 'cred-id', null, null))
       configureJenkins()
 
@@ -429,7 +429,7 @@ class IqPolicyEvaluatorIntegrationTest
       def build = project.scheduleBuild2(0).get()
 
     then: 'an exception is thrown when getting proprietary config from IQ server'
-      1 * iqClient.verifyOrCreateApplication(*_) >> true
+      1 * iqClient.verifyOrCreateApplication(*_, null) >> true
       1 * iqClient.getProprietaryConfigForApplicationEvaluation('app') >> { throw exception }
 
     then: 'the return code is successful'
@@ -456,7 +456,7 @@ class IqPolicyEvaluatorIntegrationTest
       def build = project.scheduleBuild2(0).get()
 
     then: 'the application is scanned and evaluated'
-      1 * iqClient.verifyOrCreateApplication(*_) >> true
+      1 * iqClient.verifyOrCreateApplication(*_, null) >> true
       1 * iqClient.scan(*_) >> new ScanResult(new Scan(), File.createTempFile('dummy-scan', '.xml.gz'))
       1 * iqClient.evaluateApplication(*_) >> new ApplicationPolicyEvaluation(0, 1, 2, 3, 11, 12, 13, 0, 1,
           [createAlert(Action.ID_FAIL)], 'http://server/link/to/report')
@@ -494,7 +494,7 @@ class IqPolicyEvaluatorIntegrationTest
       def build = project.scheduleBuild2(0).get()
 
     then: 'the application is scanned and evaluated'
-      1 * iqClient.verifyOrCreateApplication(*_) >> true
+      1 * iqClient.verifyOrCreateApplication(*_, null) >> true
       1 * iqClient.scan(*_) >> new ScanResult(new Scan(), File.createTempFile('dummy-scan', '.xml.gz'))
       1 * iqClient.evaluateApplication(*_) >> new ApplicationPolicyEvaluation(0, 1, 2, 3, 11, 12, 13, 0, 1,
           [createAlert(Action.ID_FAIL)], 'http://server/link/to/report')
@@ -515,7 +515,7 @@ class IqPolicyEvaluatorIntegrationTest
     given: 'a jenkins project'
       def failBuildOnNetworkError = false
       FreeStyleProject project = jenkins.createFreeStyleProject()
-      project.buildersList.add(new IqPolicyEvaluatorBuildStep(null, 'stage', new SelectedApplication('app'), [], [],
+      project.buildersList.add(new IqPolicyEvaluatorBuildStep(null, 'stage', null, new SelectedApplication('app'), [], [],
           failBuildOnNetworkError, 'cred-id', null, null))
       configureJenkins()
 
@@ -523,7 +523,7 @@ class IqPolicyEvaluatorIntegrationTest
       def build = project.scheduleBuild2(0).get()
 
     then: 'the application is scanned and evaluated'
-      1 * iqClient.verifyOrCreateApplication(*_) >> true
+      1 * iqClient.verifyOrCreateApplication(*_, null) >> true
       1 * iqClient.scan(*_) >> new ScanResult(new Scan(), File.createTempFile('dummy-scan', '.xml.gz'))
       1 * iqClient.evaluateApplication(*_) >> new ApplicationPolicyEvaluation(0, 1, 2, 3, 11, 12, 13, 0, 1,
           [createAlert(Action.ID_FAIL)], 'http://server/link/to/report')
@@ -566,7 +566,7 @@ class IqPolicyEvaluatorIntegrationTest
     given: 'a jenkins project'
       def failBuildOnNetworkError = false
       FreeStyleProject project = jenkins.createFreeStyleProject()
-      project.buildersList.add(new IqPolicyEvaluatorBuildStep(null, 'stage', new SelectedApplication('app'), [], [],
+      project.buildersList.add(new IqPolicyEvaluatorBuildStep(null, 'stage', null, new SelectedApplication('app'), [], [],
           failBuildOnNetworkError, 'cred-id', null, null))
       configureJenkins()
 
@@ -574,7 +574,7 @@ class IqPolicyEvaluatorIntegrationTest
       def build = project.scheduleBuild2(0).get()
 
     then: 'the application is scanned and evaluated'
-      1 * iqClient.verifyOrCreateApplication(*_) >> false
+      1 * iqClient.verifyOrCreateApplication(*_, null) >> false
 
     then: 'the build fails'
       jenkins.assertBuildStatus(Result.FAILURE, build)
@@ -584,7 +584,7 @@ class IqPolicyEvaluatorIntegrationTest
     given: 'a jenkins project'
       def failBuildOnNetworkError = false
       FreeStyleProject project = jenkins.createFreeStyleProject()
-      project.buildersList.add(new IqPolicyEvaluatorBuildStep(null, 'stage', new SelectedApplication('app'), [], [],
+      project.buildersList.add(new IqPolicyEvaluatorBuildStep(null, 'stage', null, new SelectedApplication('app'), [], [],
           failBuildOnNetworkError, 'cred-id', null, null))
       configureJenkins()
 
@@ -614,7 +614,7 @@ class IqPolicyEvaluatorIntegrationTest
       def build = project.scheduleBuild2(0).get()
 
     then: 'the application is scanned and evaluated'
-      1 * iqClient.verifyOrCreateApplication(*_) >> false
+      1 * iqClient.verifyOrCreateApplication(*_, null) >> false
 
     and: 'the build fails'
       jenkins.assertBuildStatus(Result.FAILURE, build)
@@ -638,7 +638,7 @@ class IqPolicyEvaluatorIntegrationTest
       def build = project.scheduleBuild2(0).get()
 
     then: 'the application is evaluated and server version is checked'
-      1 * iqClient.validateServerVersion(*_) >> { throw new Exception("server version check failed") }
+      1 * iqClient.validateServerVersion(*_, null) >> { throw new Exception("server version check failed") }
 
     and: 'the build fails'
       jenkins.assertBuildStatus(Result.FAILURE, build)
@@ -651,7 +651,7 @@ class IqPolicyEvaluatorIntegrationTest
     given: 'a jenkins project'
       FreeStyleProject project = jenkins.createFreeStyleProject()
       project.buildersList.
-          add(new IqPolicyEvaluatorBuildStep(null, 'stage', new ManualApplication('app'), [], [], false, 'cred-id',
+          add(new IqPolicyEvaluatorBuildStep(null, 'stage', null, new ManualApplication('app'), [], [], false, 'cred-id',
               null, null))
       configureJenkins()
 
@@ -659,7 +659,7 @@ class IqPolicyEvaluatorIntegrationTest
       def build = project.scheduleBuild2(0).get()
 
     then: 'the application is scanned and evaluated'
-      1 * iqClient.verifyOrCreateApplication('app') >> true
+      1 * iqClient.verifyOrCreateApplication('app', null) >> true
       1 * iqClient.scan(*_) >> new ScanResult(new Scan(), File.createTempFile('dummy-scan', '.xml.gz'))
       1 * iqClient.evaluateApplication('app', _, _, _) >> new ApplicationPolicyEvaluation(
           0, 1, 2, 3, 11, 12, 13, 0, 1, [], 'http://server/link/to/report')
@@ -677,7 +677,7 @@ class IqPolicyEvaluatorIntegrationTest
 
       FreeStyleProject project = jenkins.createFreeStyleProject()
       project.buildersList.
-          add(new IqPolicyEvaluatorBuildStep(null, 'stage', new ManualApplication('$APP'), [], [], false, 'cred-id',
+          add(new IqPolicyEvaluatorBuildStep(null, 'stage', null, new ManualApplication('$APP'), [], [], false, 'cred-id',
               null, null))
       configureJenkins()
 
@@ -685,7 +685,7 @@ class IqPolicyEvaluatorIntegrationTest
       def build = project.scheduleBuild2(0).get()
 
     then: 'the application is scanned and evaluated'
-      1 * iqClient.verifyOrCreateApplication('app') >> true
+      1 * iqClient.verifyOrCreateApplication('app', null) >> true
       1 * iqClient.scan(*_) >> new ScanResult(new Scan(), File.createTempFile('dummy-scan', '.xml.gz'))
       1 * iqClient.evaluateApplication('app', _, _, _) >> new ApplicationPolicyEvaluation(
           0, 1, 2, 3, 11, 12, 13, 0, 1, [], 'http://server/link/to/report')
@@ -698,7 +698,7 @@ class IqPolicyEvaluatorIntegrationTest
     given: 'a jenkins project'
       FreeStyleProject project = jenkins.createFreeStyleProject()
       project.buildersList.
-          add(new IqPolicyEvaluatorBuildStep(null, 'stage', new SelectedApplication('app'), [], [], false, 'cred-id',
+          add(new IqPolicyEvaluatorBuildStep(null, 'stage', null, new SelectedApplication('app'), [], [], false, 'cred-id',
               null, null))
       configureJenkins()
       def url = 'http://a.com/b/c'
@@ -711,7 +711,7 @@ class IqPolicyEvaluatorIntegrationTest
       def build = project.scheduleBuild2(0).get()
 
     then: 'the application is scanned and evaluated'
-      1 * iqClient.verifyOrCreateApplication(*_) >> true
+      1 * iqClient.verifyOrCreateApplication(*_, null) >> true
       1 * iqClient.scan(*_) >> new ScanResult(new Scan(), File.createTempFile('dummy-scan', '.xml.gz'))
       1 * iqClient.evaluateApplication(*_) >> new ApplicationPolicyEvaluation(0, 1, 2, 3, 11, 12, 13, 0, 1, [],
           'http://server/link/to/report')
@@ -727,7 +727,7 @@ class IqPolicyEvaluatorIntegrationTest
       def path = getClass().getResource('sampleRepoWithRemoteUrl.zip')
       project.setScm(new ExtractResourceSCM(path))
       project.buildersList.
-          add(new IqPolicyEvaluatorBuildStep(null, 'stage', new SelectedApplication('app'), [], [], false, 'cred-id',
+          add(new IqPolicyEvaluatorBuildStep(null, 'stage', null, new SelectedApplication('app'), [], [], false, 'cred-id',
               null, null))
       configureJenkins()
 
@@ -735,7 +735,7 @@ class IqPolicyEvaluatorIntegrationTest
       def build = project.scheduleBuild2(0).get()
 
     then: 'the application is scanned and evaluated'
-      1 * iqClient.verifyOrCreateApplication(*_) >> true
+      1 * iqClient.verifyOrCreateApplication(*_, null) >> true
       1 * iqClient.scan(*_) >> new ScanResult(new Scan(), File.createTempFile('dummy-scan', '.xml.gz'))
       1 * iqClient.evaluateApplication(*_) >> new ApplicationPolicyEvaluation(0, 0, 0, 0, 0, 0, 0, 0, 0, [],
           'http://server/link/to/report')
@@ -749,7 +749,7 @@ class IqPolicyEvaluatorIntegrationTest
     given: 'a jenkins project'
       FreeStyleProject project = jenkins.createFreeStyleProject()
       project.buildersList.
-          add(new IqPolicyEvaluatorBuildStep(null, 'stage', new SelectedApplication('app'), [], [], false, 'cred-id',
+          add(new IqPolicyEvaluatorBuildStep(null, 'stage', null, new SelectedApplication('app'), [], [], false, 'cred-id',
               null, null))
       configureJenkins()
 
@@ -757,7 +757,7 @@ class IqPolicyEvaluatorIntegrationTest
       def build = project.scheduleBuild2(0).get()
 
     then: 'the application is scanned and evaluated'
-      1 * iqClient.verifyOrCreateApplication(*_) >> true
+      1 * iqClient.verifyOrCreateApplication(*_, null) >> true
       1 * iqClient.scan(*_) >> new ScanResult(new Scan(), File.createTempFile('dummy-scan', '.xml.gz'))
       1 * iqClient.evaluateApplication(*_) >> new ApplicationPolicyEvaluation(0, 1, 2, 3, 11, 12, 13, 0, 1, [],
           'http://server/link/to/report')
@@ -794,7 +794,7 @@ class IqPolicyEvaluatorIntegrationTest
       def build = project.scheduleBuild2(0).get()
 
     then: 'the application with application id "app" is scanned and evaluated'
-      1 * iqClient.verifyOrCreateApplication('app') >> true
+      1 * iqClient.verifyOrCreateApplication('app', null) >> true
       1 * iqClient.scan(*_) >> new ScanResult(new Scan(), File.createTempFile('dummy-scan', '.xml.gz'))
       1 * iqClient.evaluateApplication(*_) >>
           new ApplicationPolicyEvaluation(0, 1, 2, 3, 11, 12, 13, 0, 1, [], 'http://server/link/to/report')
@@ -822,7 +822,7 @@ class IqPolicyEvaluatorIntegrationTest
       def build = project.scheduleBuild2(0).get()
 
     then: 'the application with application id "app" is scanned and evaluated'
-      1 * iqClient.verifyOrCreateApplication('app') >> true
+      1 * iqClient.verifyOrCreateApplication('app', null) >> true
       1 * iqClient.scan(*_) >> new ScanResult(new Scan(), File.createTempFile('dummy-scan', '.xml.gz'))
       1 * iqClient.evaluateApplication(*_) >>
           new ApplicationPolicyEvaluation(0, 1, 2, 3, 11, 12, 13, 0, 1, [], 'http://server/link/to/report')
@@ -854,7 +854,7 @@ class IqPolicyEvaluatorIntegrationTest
       def build = project.scheduleBuild2(0).get()
 
     then: 'the application with application id "app" is scanned and evaluated'
-      1 * iqClient.verifyOrCreateApplication('app') >> true
+      1 * iqClient.verifyOrCreateApplication('app', null) >> true
       1 * iqClient.scan(*_) >> new ScanResult(new Scan(), File.createTempFile('dummy-scan', '.xml.gz'))
       1 * iqClient.evaluateApplication(*_) >>
           new ApplicationPolicyEvaluation(0, 1, 2, 3, 11, 12, 13, 0, 1, [], 'http://server/link/to/report')
@@ -887,7 +887,7 @@ class IqPolicyEvaluatorIntegrationTest
       def build = project.scheduleBuild2(0).get()
 
     then: 'the application is scanned and evaluated'
-      1 * iqClient.verifyOrCreateApplication(*_) >> true
+      1 * iqClient.verifyOrCreateApplication(*_, null) >> true
       1 * iqClient.scan(*_) >> new ScanResult(new Scan(), File.createTempFile('dummy-scan', '.xml.gz'))
       1 * iqClient.evaluateApplication(*_) >> new ApplicationPolicyEvaluation(0, 1, 2, 3, 11, 12, 13, 0, 1, [],
           'http://server/link/to/report')
@@ -911,7 +911,7 @@ class IqPolicyEvaluatorIntegrationTest
       def build = project.scheduleBuild2(0).get()
 
     then: 'the application is scanned and evaluated'
-      1 * iqClient.verifyOrCreateApplication(*_) >> true
+      1 * iqClient.verifyOrCreateApplication(*_, null) >> true
       1 * iqClient.scan(*_) >> new ScanResult(new Scan(), File.createTempFile('dummy-scan', '.xml.gz'))
       1 * iqClient.evaluateApplication(*_) >> new ApplicationPolicyEvaluation(0, 1, 2, 3, 11, 12, 13, 0, 1, [],
           'http://server/link/to/report')
@@ -926,7 +926,7 @@ class IqPolicyEvaluatorIntegrationTest
       FreeStyleProject project = jenkins.createFreeStyleProject()
       Boolean enableDebugLogging = true
       project.buildersList.
-          add(new IqPolicyEvaluatorBuildStep(null, 'stage', new SelectedApplication('app'), [], [], false, 'cred-id',
+          add(new IqPolicyEvaluatorBuildStep(null, 'stage', null, new SelectedApplication('app'), [], [], false, 'cred-id',
               enableDebugLogging, null))
       configureJenkins()
 
@@ -934,7 +934,7 @@ class IqPolicyEvaluatorIntegrationTest
       def build = project.scheduleBuild2(0).get()
 
     then: 'the application is scanned and evaluated'
-      1 * iqClient.verifyOrCreateApplication(*_) >> true
+      1 * iqClient.verifyOrCreateApplication(*_, null) >> true
       1 * iqClient.scan(*_) >> new ScanResult(new Scan(), File.createTempFile('dummy-scan', '.xml.gz'))
       1 * iqClient.evaluateApplication(*_) >> new ApplicationPolicyEvaluation(0, 1, 2, 3, 11, 12, 13, 0, 1, [],
           'http://server/link/to/report')
@@ -949,7 +949,7 @@ class IqPolicyEvaluatorIntegrationTest
       FreeStyleProject project = jenkins.createFreeStyleProject()
       Boolean enableDebugLogging = false
       project.buildersList.
-          add(new IqPolicyEvaluatorBuildStep(null, 'stage', new SelectedApplication('app'), [], [], false, 'cred-id',
+          add(new IqPolicyEvaluatorBuildStep(null, 'stage', null, new SelectedApplication('app'), [], [], false, 'cred-id',
               enableDebugLogging, null))
       configureJenkins()
 
@@ -957,7 +957,7 @@ class IqPolicyEvaluatorIntegrationTest
       def build = project.scheduleBuild2(0).get()
 
     then: 'the application is scanned and evaluated'
-      1 * iqClient.verifyOrCreateApplication(*_) >> true
+      1 * iqClient.verifyOrCreateApplication(*_, null) >> true
       1 * iqClient.scan(*_) >> new ScanResult(new Scan(), File.createTempFile('dummy-scan', '.xml.gz'))
       1 * iqClient.evaluateApplication(*_) >> new ApplicationPolicyEvaluation(0, 1, 2, 3, 11, 12, 13, 0, 1, [],
           'http://server/link/to/report')

--- a/src/test/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorSlaveIntegrationTest.groovy
+++ b/src/test/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorSlaveIntegrationTest.groovy
@@ -55,7 +55,7 @@ class IqPolicyEvaluatorSlaveIntegrationTest
       FreeStyleProject project = jenkins.createFreeStyleProject()
       project.assignedNode = jenkins.createSlave()
       project.buildersList.
-          add(new IqPolicyEvaluatorBuildStep('id', 'stage', new SelectedApplication('app'), [], [], false, 'cred-id',
+          add(new IqPolicyEvaluatorBuildStep('id', 'stage', null, new SelectedApplication('app'), [], [], false, 'cred-id',
               null, null))
       configureJenkins(jenkins.jenkins, wireMockRule.port())
 
@@ -78,7 +78,7 @@ class IqPolicyEvaluatorSlaveIntegrationTest
       FreeStyleProject project = jenkins.createFreeStyleProject()
       project.assignedNode = jenkins.createSlave()
       project.buildersList.
-          add(new IqPolicyEvaluatorBuildStep('id', 'stage', new SelectedApplication('app'), [], [], false, 'cred-id',
+          add(new IqPolicyEvaluatorBuildStep('id', 'stage', null, new SelectedApplication('app'), [], [], false, 'cred-id',
               null, null))
       configureJenkins(jenkins.jenkins, wireMockRule.port())
 
@@ -97,7 +97,7 @@ class IqPolicyEvaluatorSlaveIntegrationTest
       FreeStyleProject project = jenkins.createFreeStyleProject()
       project.assignedNode = jenkins.createSlave()
       project.buildersList.
-          add(new IqPolicyEvaluatorBuildStep('id', 'stage', new SelectedApplication('app'), [], [], false, 'cred-id',
+          add(new IqPolicyEvaluatorBuildStep('id', 'stage', null, new SelectedApplication('app'), [], [], false, 'cred-id',
               null, null))
       configureJenkins(jenkins.jenkins, wireMockRule.port())
 
@@ -181,7 +181,7 @@ class IqPolicyEvaluatorSlaveIntegrationTest
       FreeStyleProject project = jenkins.createFreeStyleProject()
       project.assignedNode = jenkins.createSlave()
       project.buildersList.
-          add(new IqPolicyEvaluatorBuildStep('id', 'stage', new SelectedApplication('app'), [], [], false, 'cred-id',
+          add(new IqPolicyEvaluatorBuildStep('id', 'stage', null, new SelectedApplication('app'), [], [], false, 'cred-id',
               null, null))
       configureJenkins(jenkins.jenkins, wireMockRule.port())
 
@@ -205,7 +205,7 @@ class IqPolicyEvaluatorSlaveIntegrationTest
       def path = getClass().getResource('sampleRepoWithRemoteUrl.zip')
       project.setScm(new ExtractResourceSCM(path))
       project.buildersList.
-          add(new IqPolicyEvaluatorBuildStep('id', 'stage', new SelectedApplication('app'), [], [], false, 'cred-id',
+          add(new IqPolicyEvaluatorBuildStep('id', 'stage', null, new SelectedApplication('app'), [], [], false, 'cred-id',
               null, null))
       configureJenkins(jenkins.jenkins, wireMockRule.port())
 
@@ -280,7 +280,7 @@ class IqPolicyEvaluatorSlaveIntegrationTest
       FreeStyleProject project = jenkins.createFreeStyleProject()
       project.assignedNode = jenkins.createSlave()
       project.buildersList.
-          add(new IqPolicyEvaluatorBuildStep('id', 'stage', new SelectedApplication('app'), [], [], false, 'cred-id',
+          add(new IqPolicyEvaluatorBuildStep('id', 'stage', null, new SelectedApplication('app'), [], [], false, 'cred-id',
               null, null))
       configureJenkins(jenkins.jenkins, wireMockRule.port(), true)
 

--- a/src/test/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorTest.groovy
+++ b/src/test/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorTest.groovy
@@ -64,7 +64,7 @@ class IqPolicyEvaluatorTest
     getChannel() >> channel
   }
 
-  def workspace = new FilePath(new File("/tmp/path"))
+  def workspace = new FilePath(new File('/tmp/path'))
 
   def iqClient = Mock(InternalIqClient)
 
@@ -94,7 +94,7 @@ class IqPolicyEvaluatorTest
     GroovyMock(RemoteScannerFactory, global: true)
     GroovyMock(RemoteRepositoryUrlFinderFactory, global: true)
     iqClient.getLicensedFeatures() >> []
-    iqClient.evaluateApplication("appId", "stage", _, _) >> new ApplicationPolicyEvaluation(
+    iqClient.evaluateApplication('appId', 'stage', _, _) >> new ApplicationPolicyEvaluation(
         0, 0, 0, 0, 0, 0, 0, 0, 0, [], reportUrl)
     IqClientFactory.getIqClient(*_) >> iqClient
     remoteScanResult.copyToLocalScanResult() >> scanResult
@@ -102,7 +102,7 @@ class IqPolicyEvaluatorTest
     run.getEnvironment(_) >> envVars
     run.parent >> job
     run.workspace >> workspace
-    RemoteRepositoryUrlFinderFactory.getRepositoryUrlFinder(workspace, _, _, "appId", _) >> remoteRepositoryUrlFinder
+    RemoteRepositoryUrlFinderFactory.getRepositoryUrlFinder(workspace, _, _, 'appId', _) >> remoteRepositoryUrlFinder
     channel.call(remoteRepositoryUrlFinder) >> repositoryUrl
   }
 
@@ -115,7 +115,7 @@ class IqPolicyEvaluatorTest
       globalConfiguration.iqConfigs.add(new NxiqConfiguration('id2', 'internalId2', 'displayName2', 'serverUrl2',
           'credentialsId2', false))
       globalConfiguration.save()
-      def buildStep = new IqPolicyEvaluatorBuildStep(null, null, null, null, null, null, null, null, null)
+      def buildStep = new IqPolicyEvaluatorBuildStep(null, null, null, null, null, null, null, null, null, null)
 
     when:
       buildStep.setIqInstanceId(iqInstanceId)
@@ -156,8 +156,8 @@ class IqPolicyEvaluatorTest
 
   def 'it retrieves proprietary config followed by remote scan followed by evaluation in correct order (happy path)'() {
     setup:
-      def buildStep = new IqPolicyEvaluatorBuildStep(null, "stage", new SelectedApplication('appId'),
-          [new ScanPattern("*.jar")], [], false, null, null, null)
+      def buildStep = new IqPolicyEvaluatorBuildStep(null, 'stage', null, new SelectedApplication('appId'),
+          [new ScanPattern('*.jar')], [], false, null, null, null)
       def evaluationResult = new ApplicationPolicyEvaluation(0, 0, 0, 0, 0, 0, 0, 0, 0, emptyList(), reportUrl)
       def remoteScanner = Mock(RemoteScanner)
 
@@ -169,12 +169,12 @@ class IqPolicyEvaluatorTest
       1 * iqClient.getProprietaryConfigForApplicationEvaluation('appId') >> proprietaryConfig
 
     then: 'performs a remote scan'
-      1 * RemoteScannerFactory.getRemoteScanner("appId", "stage", ["*.jar"], [], workspace,
+      1 * RemoteScannerFactory.getRemoteScanner('appId', 'stage', ['*.jar'], [], workspace,
           proprietaryConfig, _ as Logger, _, _, _, _) >> remoteScanner
       1 * channel.call(remoteScanner) >> remoteScanResult
 
     then: 'evaluates the result'
-      1 * iqClient.evaluateApplication("appId", "stage", scanResult, _) >> evaluationResult
+      1 * iqClient.evaluateApplication('appId', 'stage', scanResult, _) >> evaluationResult
     then: 'delete the temp scan file'
       1 * localScanFile.delete() >> true
   }
@@ -182,9 +182,9 @@ class IqPolicyEvaluatorTest
   def 'it expands environment variables for scan pattern'() {
     setup:
       def remoteScanner = Mock(RemoteScanner)
-      def buildStep = new IqPolicyEvaluatorBuildStep(null, "stage", new SelectedApplication('appId'),
+      def buildStep = new IqPolicyEvaluatorBuildStep(null, 'stage', null, new SelectedApplication('appId'),
           [new ScanPattern('/path1/$SCAN_PATTERN/path2/')],
-          [], false, "131-cred", null, null)
+          [], false, '131-cred', null, null)
 
     when:
       buildStep.perform(run, launcher, Mock(BuildListener))
@@ -192,14 +192,14 @@ class IqPolicyEvaluatorTest
     then:
       1 * iqClient.verifyOrCreateApplication(*_) >> true
       1 * RemoteScannerFactory.
-          getRemoteScanner("appId", "stage", ['/path1/some-scan-pattern/path2/'], _, workspace, _, _ as Logger,
+          getRemoteScanner('appId', 'stage', ['/path1/some-scan-pattern/path2/'], _, workspace, _, _ as Logger,
               _, _, _, _) >> remoteScanner
   }
 
   def 'it ignores when no environment variables set for scan pattern'() {
     setup:
       def remoteScanner = Mock(RemoteScanner)
-      def buildStep = new IqPolicyEvaluatorBuildStep(null, "stage", new SelectedApplication('appId'),
+      def buildStep = new IqPolicyEvaluatorBuildStep(null, 'stage', null, new SelectedApplication('appId'),
           [new ScanPattern('/path1/$NONEXISTENT_SCAN_PATTERN/path2/')], [], false, '131-cred', null, null)
 
     when:
@@ -208,15 +208,15 @@ class IqPolicyEvaluatorTest
     then:
       1 * iqClient.verifyOrCreateApplication(*_) >> true
       1 * RemoteScannerFactory.
-          getRemoteScanner("appId", "stage", ['/path1/$NONEXISTENT_SCAN_PATTERN/path2/'], _, workspace, _, _ as Logger,
+          getRemoteScanner('appId', 'stage', ['/path1/$NONEXISTENT_SCAN_PATTERN/path2/'], _, workspace, _, _ as Logger,
               _, _, _, _) >> remoteScanner
   }
 
   def 'it passes module excludes to the remote scanner'() {
     setup:
       def remoteScanner = Mock(RemoteScanner)
-      def buildStep = new IqPolicyEvaluatorBuildStep(null, "stage", new SelectedApplication('appId'), [],
-          [new ModuleExclude('/path1/$NONEXISTENT_MODULE_EXCLUDE/path2/')], false, "131-cred", null, null)
+      def buildStep = new IqPolicyEvaluatorBuildStep(null, 'stage', null, new SelectedApplication('appId'), [],
+          [new ModuleExclude('/path1/$NONEXISTENT_MODULE_EXCLUDE/path2/')], false, '131-cred', null, null)
 
     when:
       buildStep.perform(run, launcher, Mock(BuildListener))
@@ -232,8 +232,8 @@ class IqPolicyEvaluatorTest
   def 'it expands environment variables for module exclude'() {
     setup:
       def remoteScanner = Mock(RemoteScanner)
-      def buildStep = new IqPolicyEvaluatorBuildStep(null, "stage", new SelectedApplication('appId'), [],
-          [new ModuleExclude('/path1/$MODULE_EXCLUDE/path2/')], false, "131-cred", null, null)
+      def buildStep = new IqPolicyEvaluatorBuildStep(null, 'stage', null, new SelectedApplication('appId'), [],
+          [new ModuleExclude('/path1/$MODULE_EXCLUDE/path2/')], false, '131-cred', null, null)
 
     when:
       buildStep.perform(run, launcher, Mock(BuildListener))
@@ -249,7 +249,7 @@ class IqPolicyEvaluatorTest
   def 'exception handling (part 1)'() {
     setup:
       iqClient.getProprietaryConfigForApplicationEvaluation('appId') >> { throw exception }
-      def buildStep = new IqPolicyEvaluatorBuildStep(null, 'stage', new SelectedApplication('appId'), [new ScanPattern('*.jar')], [],
+      def buildStep = new IqPolicyEvaluatorBuildStep(null, 'stage', null, new SelectedApplication('appId'), [new ScanPattern('*.jar')], [],
           failBuildOnNetworkError, '131-cred', null, null)
 
     when:
@@ -266,13 +266,13 @@ class IqPolicyEvaluatorTest
       new IqClientException('BOOM!!') | true                    || IqClientException | 'BOOM!!'
       new IqClientException('BOOM!!') | false                   || IqClientException | 'BOOM!!'
       new IqClientException('BOOM!!',
-          new IOException("CRASH"))   | true                    || IqClientException | 'BOOM!!'
+          new IOException('CRASH'))   | true                    || IqClientException | 'BOOM!!'
   }
 
   def 'exception handling (part 2)'() {
     setup:
       iqClient.getProprietaryConfigForApplicationEvaluation('appId') >> { throw exception }
-      def buildStep = new IqPolicyEvaluatorBuildStep(null, 'stage', new SelectedApplication('appId'), [new ScanPattern('*.jar')], [],
+      def buildStep = new IqPolicyEvaluatorBuildStep(null, 'stage', null, new SelectedApplication('appId'), [new ScanPattern('*.jar')], [],
           failBuildOnNetworkError, '131-cred', null, null)
       PrintStream logger = Mock()
       BuildListener listener = Mock() {
@@ -291,13 +291,13 @@ class IqPolicyEvaluatorTest
     where:
       exception                     | failBuildOnNetworkError || expectedException | expectedMessage
       new IqClientException('BOOM!!',
-          new IOException("CRASH")) | false                   || null              | 'BOOM!!'
+          new IOException('CRASH')) | false                   || null              | 'BOOM!!'
   }
 
   def 'it throws an exception when remote scanner fails'() {
     setup:
       iqClient.getProprietaryConfigForApplicationEvaluation('appId') >> proprietaryConfig
-      def buildStep = new IqPolicyEvaluatorBuildStep(null, 'stage', new SelectedApplication('appId'), [new ScanPattern('*.jar')], [],
+      def buildStep = new IqPolicyEvaluatorBuildStep(null, 'stage', null, new SelectedApplication('appId'), [new ScanPattern('*.jar')], [],
           false, '131-cred', null, null)
       RemoteScanner remoteScanner = Mock()
       RemoteScannerFactory.getRemoteScanner(*_) >> remoteScanner
@@ -318,7 +318,7 @@ class IqPolicyEvaluatorTest
   def 'evaluation networking exceptions are suppressed by failBuildOnNetworkError'() {
     setup:
       def failBuildOnNetworkError = false
-      def buildStep = new IqPolicyEvaluatorBuildStep(null, 'stage', new SelectedApplication('appId'), [new ScanPattern('*.jar')], [],
+      def buildStep = new IqPolicyEvaluatorBuildStep(null, 'stage', null, new SelectedApplication('appId'), [new ScanPattern('*.jar')], [],
           failBuildOnNetworkError, '131-cred', null, null)
 
     when:
@@ -336,7 +336,7 @@ class IqPolicyEvaluatorTest
 
   def 'global no credentials are passed to the client builder when no job credentials provided'() {
     setup:
-      def buildStep = new IqPolicyEvaluatorBuildStep(null, 'stage', new SelectedApplication('appId'),
+      def buildStep = new IqPolicyEvaluatorBuildStep(null, 'stage', null, new SelectedApplication('appId'),
           [new ScanPattern('*.jar')], [], true, jobCredentials, null, null)
 
     when:
@@ -355,7 +355,7 @@ class IqPolicyEvaluatorTest
 
   def 'evaluation result outcome determines build status'() {
     setup:
-      def buildStep = new IqPolicyEvaluatorBuildStep(null, 'stage', new SelectedApplication('appId'), [new ScanPattern('*.jar')], [],
+      def buildStep = new IqPolicyEvaluatorBuildStep(null, 'stage', null, new SelectedApplication('appId'), [new ScanPattern('*.jar')], [],
           false, '131-cred', null, null)
 
     when:
@@ -379,7 +379,7 @@ class IqPolicyEvaluatorTest
 
   def 'evaluation summary error count determines unstable status'() {
     setup:
-      def buildStep = new IqPolicyEvaluatorBuildStep(null, 'stage', new SelectedApplication('appId'), [new ScanPattern('*.jar')], [],
+      def buildStep = new IqPolicyEvaluatorBuildStep(null, 'stage', null, new SelectedApplication('appId'), [new ScanPattern('*.jar')], [],
           false, '131-cred', null, null)
       def scan = Mock(Scan)
       def summary = Mock(ScanSummary)
@@ -407,7 +407,7 @@ class IqPolicyEvaluatorTest
 
   def 'evaluation throws exception when build results in failure'() {
     setup:
-      def buildStep = new IqPolicyEvaluatorBuildStep(null, 'stage', new SelectedApplication('appId'), [new ScanPattern('*.jar')], [],
+      def buildStep = new IqPolicyEvaluatorBuildStep(null, 'stage', null, new SelectedApplication('appId'), [new ScanPattern('*.jar')], [],
           false, '131-cred', null, null)
       def policyEvaluation = new ApplicationPolicyEvaluation(0, 0, 0, 0, 0, 0, 0, 0, 0,
           [new PolicyAlert(null, [new Action(Action.ID_FAIL)])], reportUrl)
@@ -437,7 +437,7 @@ class IqPolicyEvaluatorTest
       scan.summary >> summary
       summary.errorCount >> 1
 
-      def buildStep = new IqPolicyEvaluatorBuildStep(null, 'stage', new SelectedApplication('appId'), [new ScanPattern('*.jar')], [],
+      def buildStep = new IqPolicyEvaluatorBuildStep(null, 'stage', null, new SelectedApplication('appId'), [new ScanPattern('*.jar')], [],
           false, '131-cred', null, null)
       def policyEvaluation = new ApplicationPolicyEvaluation(0, 0, 0, 0, 0, 0, 0, 0, 0,
           [new PolicyAlert(null, [new Action(Action.ID_FAIL)])], reportUrl)
@@ -463,7 +463,7 @@ class IqPolicyEvaluatorTest
   @Unroll
   def 'prints an error message on failure when configured with hideReports = #hideReports'() {
     setup:
-      def buildStep = new IqPolicyEvaluatorBuildStep(null, 'stage', new SelectedApplication('appId'), [new ScanPattern('*.jar')], [],
+      def buildStep = new IqPolicyEvaluatorBuildStep(null, 'stage', null, new SelectedApplication('appId'), [new ScanPattern('*.jar')], [],
           false, '131-cred', null, null)
       BuildListener listener = Mock()
       PrintStream log = Mock()
@@ -502,7 +502,7 @@ class IqPolicyEvaluatorTest
   @Unroll
   def 'prints a log message on warnings when configured with hideReports = #hideReports'() {
     setup:
-      def buildStep = new IqPolicyEvaluatorBuildStep(null, 'stage', new SelectedApplication('appId'), [new ScanPattern('*.jar')], [],
+      def buildStep = new IqPolicyEvaluatorBuildStep(null, 'stage', null, new SelectedApplication('appId'), [new ScanPattern('*.jar')], [],
           false, '131-cred', null, null)
       BuildListener listener = Mock()
       PrintStream log = Mock()
@@ -522,7 +522,7 @@ class IqPolicyEvaluatorTest
       1 * iqClient.evaluateApplication('appId', 'stage', scanResult, _) >>
           new ApplicationPolicyEvaluation(0, 1, 2, 3, 11, 12, 13, 0, 1,
               [new PolicyAlert(trigger, [new Action(Action.ID_WARN)])], reportUrl)
-      1 * log.println("IQ Server evaluation of application appId detected warnings")
+      1 * log.println('IQ Server evaluation of application appId detected warnings')
       (hideReports ? 0 : 1) * log.println(
           'Nexus IQ reports policy warning due to \nPolicy(policyName) [\n Component(displayName=value, ' +
               'hash=12hash34) [\n  Constraint(constraintName) [summary because: reason] ]]\nThe detailed report can be' +
@@ -537,7 +537,7 @@ class IqPolicyEvaluatorTest
 
   def 'prints a summary on success'() {
     setup:
-      def buildStep = new IqPolicyEvaluatorBuildStep(null, 'stage', new SelectedApplication('appId'), [new ScanPattern('*.jar')], [],
+      def buildStep = new IqPolicyEvaluatorBuildStep(null, 'stage', null, new SelectedApplication('appId'), [new ScanPattern('*.jar')], [],
           false, '131-cred', null, null)
       BuildListener listener = Mock()
       PrintStream log = Mock()
@@ -551,7 +551,7 @@ class IqPolicyEvaluatorTest
       1 * iqClient.evaluateApplication('appId', 'stage', scanResult, _) >>
           new ApplicationPolicyEvaluation(0, 0, 0, 0, 0, 0, 0, 0, 0, [],
               reportUrl)
-      0 * log.println("WARNING: IQ Server evaluation of application appId detected warnings.")
+      0 * log.println('WARNING: IQ Server evaluation of application appId detected warnings.')
       1 * log.println('\nThe detailed report can be viewed online at http://server/report\n' +
           'Summary of policy violations: 0 critical, 0 severe, 0 moderate')
     and: 'delete the temp scan file'
@@ -561,8 +561,8 @@ class IqPolicyEvaluatorTest
 
   def 'prints an error message if not in node context'() {
     setup:
-      def buildStep = new IqPolicyEvaluatorBuildStep(null, "stage", new SelectedApplication('appId'),
-          [new ScanPattern("*.jar")], [],false, null, null, null)
+      def buildStep = new IqPolicyEvaluatorBuildStep(null, 'stage', null, new SelectedApplication('appId'),
+          [new ScanPattern('*.jar')], [],false, null, null, null)
       def listener = Mock(BuildListener)
 
     when:
@@ -576,8 +576,8 @@ class IqPolicyEvaluatorTest
 
   def 'it adds or updates source control with the retrieved repo url'() {
     setup:
-      def buildStep = new IqPolicyEvaluatorBuildStep(null, "stage", new SelectedApplication('appId'),
-          [new ScanPattern("*.jar")], [],
+      def buildStep = new IqPolicyEvaluatorBuildStep(null, 'stage', null, new SelectedApplication('appId'),
+          [new ScanPattern('*.jar')], [],
           false, null, null, null)
       def evaluationResult = new ApplicationPolicyEvaluation(0, 0, 0, 0, 0, 0, 0, 0, 0, emptyList(), reportUrl)
       def remoteScanner = Mock(RemoteScanner)
@@ -590,18 +590,18 @@ class IqPolicyEvaluatorTest
       1 * iqClient.getProprietaryConfigForApplicationEvaluation('appId') >> proprietaryConfig
 
     then: 'performs a remote scan'
-      1 * RemoteScannerFactory.getRemoteScanner("appId", "stage", ["*.jar"], [], workspace,
+      1 * RemoteScannerFactory.getRemoteScanner('appId', 'stage', ['*.jar'], [], workspace,
           proprietaryConfig, _ as Logger, _, _, _, _) >> remoteScanner
       1 * channel.call(remoteScanner) >> remoteScanResult
 
     then: 'performs a remote scan'
-      1 * RemoteRepositoryUrlFinderFactory.getRepositoryUrlFinder(workspace, _, _, "appId", _) >>
+      1 * RemoteRepositoryUrlFinderFactory.getRepositoryUrlFinder(workspace, _, _, 'appId', _) >>
           remoteRepositoryUrlFinder
       1 * channel.call(remoteRepositoryUrlFinder) >> repositoryUrl
-      1 * iqClient.addOrUpdateSourceControl("appId", repositoryUrl)
+      1 * iqClient.addOrUpdateSourceControl('appId', repositoryUrl)
 
     then: 'evaluates the result'
-      1 * iqClient.evaluateApplication("appId", "stage", scanResult, _) >> evaluationResult
+      1 * iqClient.evaluateApplication('appId', 'stage', scanResult, _) >> evaluationResult
     and: 'delete the temp scan file'
       1 * localScanFile.delete() >> true
       1 * remoteScanResult.delete() >> true


### PR DESCRIPTION
Adding support to add Organization Id as an optional parameter for nexus IQ policy evaluation

JIRA: https://issues.sonatype.org/browse/INT-7157
Build: https://jenkins.ci.sonatype.dev/job/integrations/job/jenkins/job/feature-snapshots/job/INT-7157-add-org-id-param-to-pipeline-syntax/