### PR TITLE
INT-7228 Fixing build report for notify actions

### DIFF
--- a/src/main/java/org/sonatype/nexus/ci/iq/PolicyEvaluationReportUtil.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/iq/PolicyEvaluationReportUtil.groovy
@@ -12,6 +12,7 @@
  */
 package org.sonatype.nexus.ci.iq
 
+import com.sonatype.nexus.api.iq.Action
 import com.sonatype.nexus.api.iq.ApplicationPolicyEvaluation
 import com.sonatype.nexus.api.iq.ComponentFact
 import com.sonatype.nexus.api.iq.ConditionFact
@@ -47,9 +48,11 @@ class PolicyEvaluationReportUtil
       int warnCurrent = 0
 
       for (Constraint constraint: comp.constraints) {
-        if (constraint.action == 'warn') {
+        if (constraint.action == Action.ID_WARN) {
           warnCurrent++
-        } else {
+        }
+
+        if (constraint.action == Action.ID_FAIL) {
           failedCurrent++
         }
       }

--- a/src/main/resources/org/sonatype/nexus/ci/iq/PolicyEvaluationReportAction/index.jelly
+++ b/src/main/resources/org/sonatype/nexus/ci/iq/PolicyEvaluationReportAction/index.jelly
@@ -228,9 +228,14 @@
         padding: 5px 5px 5px 20px;
       }
 
-      .violations-details .col2 svg.iq-failed-icon,
       .violations-details .col2 svg.iq-warning-icon {
         float: left;
+      }
+
+      .violations-details .col2 svg.iq-failed-icon,
+      .violations-details .col2 svg.iq-info-icon {
+        float: left;
+        margin-top: 2px;
       }
 
       .violations-details .col2 div.policy-action {
@@ -322,6 +327,10 @@
 
       .iq-warning-icon circle {
         fill: #f4861d;
+      }
+
+      .iq-info-icon circle {
+        fill: #97cbee;
       }
 
       div.iq-space-ship {
@@ -444,7 +453,7 @@
                           </path>
                         </svg>
                       </j:when>
-                      <j:otherwise>
+                      <j:when test="${constraint.action.equalsIgnoreCase('fail')}">
                         <svg class="iq-failed-icon" height="16" viewBox="0 0 512 512" width="16"
                              xmlns="http://www.w3.org/2000/svg" focusable="false">
                           <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8
@@ -455,7 +464,19 @@
                               fill="#bc012f">
                           </path>
                         </svg>
-                      </j:otherwise>
+                      </j:when>
+                      <j:when test="${constraint.action.equalsIgnoreCase('notify')}">
+                        <svg class="iq-info-icon" height="16" viewBox="0 0 512 512" width="16"
+                             xmlns="http://www.w3.org/2000/svg" focusable="false">
+                          <path d="M504 256c0-136.997-111.043-248-248-248S8 119.003 8 256C8 392.917 119.043 504
+                           256 504s248-111.083 248-248zm-248-50c-25.405 0-46-20.595-46-46s20.595-46 46-46 46 20.595
+                            46 46-20.595 46-46 46zm-43.673 165.346 7.418-136c.347-6.364 5.609-11.346
+                            11.982-11.346h48.546c6.373 0 11.635 4.982 11.982 11.346l7.418 136c.375 6.874-5.098
+                            12.654-11.982 12.654h-63.383c-6.884 0-12.356-5.78-11.981-12.654z"
+                              fill="#97cbee">
+                          </path>
+                        </svg>
+                      </j:when>
                     </j:choose>
                     <div class="policy-action">${constraint.action}</div>
                   </div>


### PR DESCRIPTION
Fixing build report to show notify actions with proper icon and ensure they are not counted as failure actions

JIRA: https://issues.sonatype.org/browse/INT-7228
Build: https://jenkins.ci.sonatype.dev/job/integrations/job/jenkins/job/feature-snapshots/job/INT-7228-fixing-build-report-for-notify-actions/

Screenshot
-------------
This is how the new icon for the Notify action is displayed 

![image](https://user-images.githubusercontent.com/20423049/190717426-bf8f7257-c06d-4215-8973-3fdd3fe35e2b.png)
