### PR TITLE
INT-7295 Solving ANTLR version mismatch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -332,6 +332,7 @@
               org.codehaus.stax2.
               com.ctc.wstx.
               org.objectweb.asm.
+              org.antlr.v4.
             </maskClasses>
           </configuration>
         </plugin>


### PR DESCRIPTION
Jenkins plugin was resolving the wrong dependency for ANTLR. With this change, we ensure our plugin looks for the right dependency on the bundled libraries.

JIRA: https://issues.sonatype.org/browse/INT-7295
Build: https://jenkins.ci.sonatype.dev/job/integrations/job/jenkins/job/feature-snapshots/job/INT-7295-solving-antlr-version-mismatch/