### PR TITLE
INT-7476 Check compatibility with Jenkins version 2.361.4

### DIFF
--- a/Jenkinsfile.sonatype.extra-tests
+++ b/Jenkinsfile.sonatype.extra-tests
@@ -44,11 +44,11 @@ pipeline {
             }
           }
         }
-        stage('Jenkins 2.361.3 - Java 11') {
+        stage('Jenkins 2.361.4 - Java 11') {
           agent { label agentLabel }
           steps {
             runTests('OpenJDK 11',
-                '-Djenkins.version=2.361.3 -Djenkins.tools.bom.artifactId=bom-2.361.x -Djenkins.tools.bom.version=1678.vc1feb_6a_3c0f1')
+                '-Djenkins.version=2.361.4 -Djenkins.tools.bom.artifactId=bom-2.361.x -Djenkins.tools.bom.version=1706.vc166d5f429f8')
           }
           post {
             always {


### PR DESCRIPTION
**Links**
Jira: https://issues.sonatype.org/browse/INT-7476
Build: https://jenkins.ci.sonatype.dev/job/integrations/job/jenkins/job/feature-snapshots/job/INT-7476_Check_compatibility_Jenkins_2.361.4/
