### PR TITLE
Adapt 'l.css' removal in Jenkins 2.401 onwards

### DIFF
--- a/src/main/resources/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorBuildStep/config.groovy
+++ b/src/main/resources/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorBuildStep/config.groovy
@@ -22,7 +22,7 @@ def f = namespace(lib.FormTagLib)
 def c = namespace(lib.CredentialsTagLib)
 def l = namespace(lib.LayoutTagLib)
 
-l.css(src: "${rootURL}/plugin/nexus-jenkins-plugin/css/nexus.css")
+link(rel: "stylesheet", href: "${rootURL}/plugin/nexus-jenkins-plugin/css/nexus.css", type: "text/css")
 
 f.section(title: descriptor.displayName) {
   if (!IqUtil.hasIqConfiguration()) {

--- a/src/main/resources/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorWorkflowStep/config.groovy
+++ b/src/main/resources/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorWorkflowStep/config.groovy
@@ -22,7 +22,7 @@ def f = namespace(lib.FormTagLib)
 def c = namespace(lib.CredentialsTagLib)
 def l = namespace(lib.LayoutTagLib)
 
-l.css(src: "${rootURL}/plugin/nexus-jenkins-plugin/css/nexus.css")
+link(rel: "stylesheet", href: "${rootURL}/plugin/nexus-jenkins-plugin/css/nexus.css", type: "text/css")
 
 f.section(title: descriptor.displayName) {
   if (!IqUtil.hasIqConfiguration()) {

--- a/src/main/resources/org/sonatype/nexus/ci/nxrm/NexusPublisherBuildStep/config.groovy
+++ b/src/main/resources/org/sonatype/nexus/ci/nxrm/NexusPublisherBuildStep/config.groovy
@@ -38,7 +38,7 @@ script() {
   ''')
 }
 
-l.css(src: "${rootURL}/plugin/nexus-jenkins-plugin/css/nexus.css")
+link(rel: "stylesheet", href: "${rootURL}/plugin/nexus-jenkins-plugin/css/nexus.css", type: "text/css")
 
 f.section(title: descriptor.displayName) {
   if (!NxrmUtil.hasNexusRepositoryManagerConfiguration()) {

--- a/src/main/resources/org/sonatype/nexus/ci/nxrm/NexusPublisherWorkflowStep/config.groovy
+++ b/src/main/resources/org/sonatype/nexus/ci/nxrm/NexusPublisherWorkflowStep/config.groovy
@@ -38,7 +38,7 @@ script() {
   ''')
 }
 
-l.css(src: "${rootURL}/plugin/nexus-jenkins-plugin/css/nexus.css")
+link(rel: "stylesheet", href: "${rootURL}/plugin/nexus-jenkins-plugin/css/nexus.css", type: "text/css")
 
 f.section(title: descriptor.displayName) {
   if (!NxrmUtil.hasNexusRepositoryManagerConfiguration()) {

--- a/src/main/resources/org/sonatype/nexus/ci/nxrm/v3/AssociateTagStep/config.groovy
+++ b/src/main/resources/org/sonatype/nexus/ci/nxrm/v3/AssociateTagStep/config.groovy
@@ -17,7 +17,7 @@ import org.sonatype.nexus.ci.util.NxrmUtil
 def f = namespace(lib.FormTagLib)
 def l = namespace(lib.LayoutTagLib)
 
-l.css(src: "plugin/nexus-jenkins-plugin/css/nexus.css")
+link(rel: "stylesheet", href: "plugin/nexus-jenkins-plugin/css/nexus.css", type: "text/css")
 
 f.section() {
   if (!NxrmUtil.hasNexusRepositoryManagerConfiguration()) {

--- a/src/main/resources/org/sonatype/nexus/ci/nxrm/v3/CreateTagStep/config.groovy
+++ b/src/main/resources/org/sonatype/nexus/ci/nxrm/v3/CreateTagStep/config.groovy
@@ -17,7 +17,7 @@ import org.sonatype.nexus.ci.util.NxrmUtil
 def f = namespace(lib.FormTagLib)
 def l = namespace(lib.LayoutTagLib)
 
-l.css(src: "plugin/nexus-jenkins-plugin/css/nexus.css")
+link(rel: "stylesheet", href: "plugin/nexus-jenkins-plugin/css/nexus.css", type: "text/css")
 
 f.section() {
   if (!NxrmUtil.hasNexusRepositoryManagerConfiguration()) {

--- a/src/main/resources/org/sonatype/nexus/ci/nxrm/v3/DeleteComponentsStep/config.groovy
+++ b/src/main/resources/org/sonatype/nexus/ci/nxrm/v3/DeleteComponentsStep/config.groovy
@@ -17,7 +17,7 @@ import org.sonatype.nexus.ci.util.NxrmUtil
 def f = namespace(lib.FormTagLib)
 def l = namespace(lib.LayoutTagLib)
 
-l.css(src: "plugin/nexus-jenkins-plugin/css/nexus.css")
+link(rel: "stylesheet", href: "plugin/nexus-jenkins-plugin/css/nexus.css", type: "text/css")
 
 f.section() {
   if (!NxrmUtil.hasNexusRepositoryManagerConfiguration()) {

--- a/src/main/resources/org/sonatype/nexus/ci/nxrm/v3/MoveComponentsStep/config.groovy
+++ b/src/main/resources/org/sonatype/nexus/ci/nxrm/v3/MoveComponentsStep/config.groovy
@@ -17,7 +17,7 @@ import org.sonatype.nexus.ci.util.NxrmUtil
 def f = namespace(lib.FormTagLib)
 def l = namespace(lib.LayoutTagLib)
 
-l.css(src: "plugin/nexus-jenkins-plugin/css/nexus.css")
+link(rel: "stylesheet", href: "plugin/nexus-jenkins-plugin/css/nexus.css", type: "text/css")
 
 f.section() {
   if (!NxrmUtil.hasNexusRepositoryManagerConfiguration()) {


### PR DESCRIPTION
In 2.401, we have removed `l:css` from core, when we dropped the dependency on `jenkins-js-modules`. Therefore, `l.css`, the groovy equivalent, is gone too, but it appears the only two plugins using groovy views and `l.css` weren't updated.
Hence, I'm filing this PR retrospectively.

In groovy, `link` is equal to the HTML tag `<link>`, this PR makes use of, working independently of Jenkins versions.