### PR TITLE
Bump innersource dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,10 +30,16 @@
 
   <repositories>
     <repository>
-      <id>maven.jenkins-ci.org</id>
-      <url>https://repo.jenkins-ci.org/releases/</url>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
     </repository>
   </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </pluginRepository>
+  </pluginRepositories>
 
   <name>Nexus Platform Plugin</name>
   <url>https://github.com/jenkinsci/nexus-platform-plugin</url>

--- a/pom.xml
+++ b/pom.xml
@@ -33,10 +33,6 @@
       <id>repo.jenkins-ci.org</id>
       <url>https://repo.jenkins-ci.org/public/</url>
     </repository>
-    <repository>
-      <id>central</id>
-      <url>https://repo1.maven.org/maven2/</url>
-    </repository>
   </repositories>
   <pluginRepositories>
     <pluginRepository>

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,10 @@
       <id>repo.jenkins-ci.org</id>
       <url>https://repo.jenkins-ci.org/public/</url>
     </repository>
+    <repository>
+      <id>central</id>
+      <url>https://repo1.maven.org/maven2/</url>
+    </repository>
   </repositories>
   <pluginRepositories>
     <pluginRepository>

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
     <enforcer.skip>true</enforcer.skip> <!-- TODO numerous requireUpperBoundDeps, some probably indicative of real problems -->
     <jvnet-localizer-plugin.version>1.23</jvnet-localizer-plugin.version>
     <forkCount>1</forkCount>
-    <nexus-platform-api.version>4.1.8-01</nexus-platform-api.version>
+    <nexus-platform-api.version>4.1.10-01</nexus-platform-api.version>
 
     <buildsupport.version>36</buildsupport.version>
     <buildsupport.license-maven-plugin.version>4.1</buildsupport.license-maven-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -30,16 +30,10 @@
 
   <repositories>
     <repository>
-      <id>repo.jenkins-ci.org</id>
-      <url>https://repo.jenkins-ci.org/public/</url>
+      <id>maven.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/releases/</url>
     </repository>
   </repositories>
-  <pluginRepositories>
-    <pluginRepository>
-      <id>repo.jenkins-ci.org</id>
-      <url>https://repo.jenkins-ci.org/public/</url>
-    </pluginRepository>
-  </pluginRepositories>
 
   <name>Nexus Platform Plugin</name>
   <url>https://github.com/jenkinsci/nexus-platform-plugin</url>


### PR DESCRIPTION
Bump innersource dependencies for `nexus-platform-plugin`.

Build: https://jenkins.ci.sonatype.dev/job/integrations/job/jenkins/job/feature-snapshots/job/bump-innersource-dependencies-9c7250/