### PR TITLE
chore(pom.xml) remove pluginRepositories section

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,12 +34,6 @@
       <url>https://repo.jenkins-ci.org/public/</url>
     </repository>
   </repositories>
-  <pluginRepositories>
-    <pluginRepository>
-      <id>repo.jenkins-ci.org</id>
-      <url>https://repo.jenkins-ci.org/public/</url>
-    </pluginRepository>
-  </pluginRepositories>
 
   <name>Nexus Platform Plugin</name>
   <url>https://github.com/jenkinsci/nexus-platform-plugin</url>


### PR DESCRIPTION
This (draft) aims at validating the behavior of the new `settings.xml` of ci.jenkins.io which controls the `pluginRepositories` resolution order in the Jenkins infra context (as the plugin pom parent should provide the "normal" information).

It is related to https://github.com/jenkins-infra/helpdesk/issues/3599#issuecomment-1701151279