### PR TITLE
CLM-27258: Updated the latest version of JenkinsCI 2.414.1 to be tested with Java 17

### DIFF
--- a/Jenkinsfile.sonatype.extra-tests
+++ b/Jenkinsfile.sonatype.extra-tests
@@ -56,10 +56,10 @@ pipeline {
             }
           }
         }
-        stage('Jenkins 2.414.1 - Java 11') {
+        stage('Jenkins 2.414.1 - Java 17') {
           agent { label agentLabel }
           steps {
-            runTests('OpenJDK 11',
+            runTests('OpenJDK 17',
                 '-Djenkins.version=2.414.1 -Djenkins.tools.bom.artifactId=bom-2.414.x -Djenkins.tools.bom.version=2401.v7a_d68f8d0b_09')
           }
           post {

--- a/Jenkinsfile.sonatype.extra-tests
+++ b/Jenkinsfile.sonatype.extra-tests
@@ -44,11 +44,11 @@ pipeline {
             }
           }
         }
-        stage('Jenkins 2.414.1 - Java 11') {
+        stage('Jenkins 2.401.1 - Java 11') {
           agent { label agentLabel }
           steps {
             runTests('OpenJDK 11',
-                '-Djenkins.version=2.414.1 -Djenkins.tools.bom.artifactId=bom-2.414.x -Djenkins.tools.bom.version=2378.v3e03930028f2')
+                '-Djenkins.version=2.401.1 -Djenkins.tools.bom.artifactId=bom-2.401.x -Djenkins.tools.bom.version=2163.v2d916d90c305')
           }
           post {
             always {

--- a/Jenkinsfile.sonatype.extra-tests
+++ b/Jenkinsfile.sonatype.extra-tests
@@ -56,10 +56,10 @@ pipeline {
             }
           }
         }
-        stage('Jenkins 2.414.1 - Java 17') {
+        stage('Jenkins 2.414.1 - Java 11') {
           agent { label agentLabel }
           steps {
-            runTests('OpenJDK 17',
+            runTests('OpenJDK 11',
                 '-Djenkins.version=2.414.1 -Djenkins.tools.bom.artifactId=bom-2.414.x -Djenkins.tools.bom.version=2401.v7a_d68f8d0b_09')
           }
           post {

--- a/Jenkinsfile.sonatype.extra-tests
+++ b/Jenkinsfile.sonatype.extra-tests
@@ -44,11 +44,11 @@ pipeline {
             }
           }
         }
-        stage('Jenkins 2.401.1 - Java 11') {
+        stage('Jenkins 2.414.1 - Java 11') {
           agent { label agentLabel }
           steps {
             runTests('OpenJDK 11',
-                '-Djenkins.version=2.401.1 -Djenkins.tools.bom.artifactId=bom-2.401.x -Djenkins.tools.bom.version=2163.v2d916d90c305')
+                '-Djenkins.version=2.414.1 -Djenkins.tools.bom.artifactId=bom-2.414.x -Djenkins.tools.bom.version=2378.v3e03930028f2')
           }
           post {
             always {
@@ -56,11 +56,11 @@ pipeline {
             }
           }
         }
-        stage('Jenkins 2.401.1 - Java 17') {
+        stage('Jenkins 2.414.1 - Java 17') {
           agent { label agentLabel }
           steps {
             runTests('OpenJDK 17',
-                '-Djenkins.version=2.401.1 -Djenkins.tools.bom.artifactId=bom-2.401.x -Djenkins.tools.bom.version=2163.v2d916d90c305')
+                '-Djenkins.version=2.414.1 -Djenkins.tools.bom.artifactId=bom-2.414.x -Djenkins.tools.bom.version=2378.v3e03930028f2')
           }
           post {
             always {

--- a/Jenkinsfile.sonatype.extra-tests
+++ b/Jenkinsfile.sonatype.extra-tests
@@ -56,6 +56,18 @@ pipeline {
             }
           }
         }
+        stage('Jenkins 2.401.1 - Java 17') {
+          agent { label agentLabel }
+          steps {
+            runTests('OpenJDK 17',
+                '-Djenkins.version=2.401.1 -Djenkins.tools.bom.artifactId=bom-2.401.x -Djenkins.tools.bom.version=2401.v7a_d68f8d0b_09')
+          }
+          post {
+            always {
+              captureResultsAndCleanup()
+            }
+          }
+        }
         stage('Jenkins 2.414.1 - Java 17') {
           agent { label agentLabel }
           steps {

--- a/Jenkinsfile.sonatype.extra-tests
+++ b/Jenkinsfile.sonatype.extra-tests
@@ -72,7 +72,7 @@ pipeline {
           agent { label agentLabel }
           steps {
             runTests('OpenJDK 17',
-                '-Djenkins.version=2.414.1 -Djenkins.tools.bom.artifactId=bom-2.414.x -Djenkins.tools.bom.version=2378.v3e03930028f2')
+                '-Djenkins.version=2.414.1 -Djenkins.tools.bom.artifactId=bom-2.414.x -Djenkins.tools.bom.version=2401.v7a_d68f8d0b_09')
           }
           post {
             always {

--- a/Jenkinsfile.sonatype.extra-tests
+++ b/Jenkinsfile.sonatype.extra-tests
@@ -56,18 +56,6 @@ pipeline {
             }
           }
         }
-        stage('Jenkins 2.401.1 - Java 17') {
-          agent { label agentLabel }
-          steps {
-            runTests('OpenJDK 17',
-                '-Djenkins.version=2.401.1 -Djenkins.tools.bom.artifactId=bom-2.401.x -Djenkins.tools.bom.version=2401.v7a_d68f8d0b_09')
-          }
-          post {
-            always {
-              captureResultsAndCleanup()
-            }
-          }
-        }
         stage('Jenkins 2.414.1 - Java 17') {
           agent { label agentLabel }
           steps {

--- a/src/test/java/org/sonatype/nexus/ci/iq/PipelineSyntaxIntegrationTest.groovy
+++ b/src/test/java/org/sonatype/nexus/ci/iq/PipelineSyntaxIntegrationTest.groovy
@@ -53,6 +53,7 @@ class PipelineSyntaxIntegrationTest
     given: 'a pipleline project'
       WorkflowJob project = jenkins.createProject(WorkflowJob)
       WebClient client = jenkins.createWebClient()
+      client.getOptions().setFetchPolyfillEnabled(true)
 
     when: 'the pipeline syntax page is loaded'
       HtmlOption policyEval = selectPolicyEvaluation(client, project)
@@ -80,6 +81,7 @@ class PipelineSyntaxIntegrationTest
       configureJenkins(jenkins.jenkins, wireMockRule.port())
       WorkflowJob project = jenkins.createProject(WorkflowJob)
       WebClient client = jenkins.createWebClient()
+      client.getOptions().setFetchPolyfillEnabled(true)
 
     when: 'the pipeline syntax page is loaded'
       HtmlOption policyEval = selectPolicyEvaluation(client, project)


### PR DESCRIPTION
JenkinsCI version 2.414.1

Ref: CLM-27258

Jenkins https://jenkins.ci.sonatype.dev/job/integrations/job/jenkins/job/feature-snapshots/job/CLM-27258/
Jira https://sonatype.atlassian.net/browse/CLM-27258

This PR replaces https://github.com/jenkinsci/nexus-platform-plugin/pull/281