### PR TITLE
 Add protection from CSRF

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
     <enforcer.skip>true</enforcer.skip> <!-- TODO numerous requireUpperBoundDeps, some probably indicative of real problems -->
     <jvnet-localizer-plugin.version>1.23</jvnet-localizer-plugin.version>
     <forkCount>1</forkCount>
-    <nexus-platform-api.version>4.3.1-01</nexus-platform-api.version>
+    <nexus-platform-api.version>4.3.2-01</nexus-platform-api.version>
 
     <buildsupport.version>36</buildsupport.version>
     <buildsupport.license-maven-plugin.version>4.1</buildsupport.license-maven-plugin.version>

--- a/src/main/java/org/sonatype/nexus/ci/config/NxiqConfiguration.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/config/NxiqConfiguration.groovy
@@ -24,6 +24,7 @@ import hudson.util.ListBoxModel
 import jenkins.model.Jenkins
 import org.kohsuke.stapler.DataBoundConstructor
 import org.kohsuke.stapler.QueryParameter
+import org.kohsuke.stapler.verb.POST
 
 class NxiqConfiguration
     implements Describable<NxiqConfiguration>
@@ -83,6 +84,7 @@ class NxiqConfiguration
       Messages.NxiqConfiguration_DisplayName()
     }
 
+    @POST
     FormValidation doCheckDisplayName(@QueryParameter String value, @QueryParameter String internalId) {
       def globalConfigurations = GlobalNexusConfiguration.globalNexusConfiguration
       for (NxiqConfiguration config : globalConfigurations.iqConfigs) {
@@ -93,6 +95,7 @@ class NxiqConfiguration
       return FormUtil.validateNotEmpty(value, 'Display Name is required')
     }
 
+    @POST
     FormValidation doCheckId(@QueryParameter String value, @QueryParameter String internalId) {
       def globalConfigurations = GlobalNexusConfiguration.globalNexusConfiguration
       for (NxiqConfiguration config : globalConfigurations.iqConfigs) {
@@ -108,6 +111,7 @@ class NxiqConfiguration
     }
 
     @SuppressWarnings('unused')
+    @POST
     FormValidation doCheckServerUrl(@QueryParameter String value) {
       def validation = FormUtil.validateUrl(value)
       if (validation.kind == Kind.OK) {
@@ -123,6 +127,7 @@ class NxiqConfiguration
     }
 
     @SuppressWarnings('unused')
+    @POST
     FormValidation doVerifyCredentials(
         @QueryParameter String serverUrl,
         @QueryParameter String credentialsId) throws IOException

--- a/src/main/java/org/sonatype/nexus/ci/config/NxiqConfiguration.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/config/NxiqConfiguration.groovy
@@ -86,6 +86,7 @@ class NxiqConfiguration
 
     @POST
     FormValidation doCheckDisplayName(@QueryParameter String value, @QueryParameter String internalId) {
+      Jenkins.get().checkPermission(Jenkins.ADMINISTER)
       def globalConfigurations = GlobalNexusConfiguration.globalNexusConfiguration
       for (NxiqConfiguration config : globalConfigurations.iqConfigs) {
         if (config.internalId != internalId && config.displayName == value) {
@@ -97,6 +98,7 @@ class NxiqConfiguration
 
     @POST
     FormValidation doCheckId(@QueryParameter String value, @QueryParameter String internalId) {
+      Jenkins.get().checkPermission(Jenkins.ADMINISTER)
       def globalConfigurations = GlobalNexusConfiguration.globalNexusConfiguration
       for (NxiqConfiguration config : globalConfigurations.iqConfigs) {
         if (config.internalId != internalId && config.id == value) {
@@ -113,6 +115,7 @@ class NxiqConfiguration
     @SuppressWarnings('unused')
     @POST
     FormValidation doCheckServerUrl(@QueryParameter String value) {
+      Jenkins.get().checkPermission(Jenkins.ADMINISTER)
       def validation = FormUtil.validateUrl(value)
       if (validation.kind == Kind.OK) {
         validation = FormUtil.validateNotEmpty(value, Messages.Configuration_ServerUrlRequired())
@@ -132,6 +135,7 @@ class NxiqConfiguration
         @QueryParameter String serverUrl,
         @QueryParameter String credentialsId) throws IOException
     {
+      Jenkins.get().checkPermission(Jenkins.ADMINISTER)
       return IqUtil.verifyJobCredentials(serverUrl, credentialsId, Jenkins.instance)
     }
   }

--- a/src/main/java/org/sonatype/nexus/ci/config/Nxrm2Configuration.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/config/Nxrm2Configuration.groovy
@@ -18,6 +18,7 @@ import org.sonatype.nexus.ci.config.NxrmConfiguration.NxrmDescriptor
 
 import hudson.Extension
 import hudson.util.FormValidation
+import jenkins.model.Jenkins
 import org.kohsuke.stapler.DataBoundConstructor
 import org.kohsuke.stapler.QueryParameter
 import org.kohsuke.stapler.verb.POST
@@ -63,6 +64,8 @@ class Nxrm2Configuration
     FormValidation doVerifyCredentials(@QueryParameter String serverUrl, @QueryParameter String credentialsId)
         throws IOException
     {
+      Jenkins.get().checkPermission(Jenkins.ADMINISTER)
+
       try {
         def repositories = getApplicableRepositories(serverUrl, credentialsId)
 

--- a/src/main/java/org/sonatype/nexus/ci/config/Nxrm2Configuration.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/config/Nxrm2Configuration.groovy
@@ -20,6 +20,7 @@ import hudson.Extension
 import hudson.util.FormValidation
 import org.kohsuke.stapler.DataBoundConstructor
 import org.kohsuke.stapler.QueryParameter
+import org.kohsuke.stapler.verb.POST
 
 import static hudson.util.FormValidation.error
 import static hudson.util.FormValidation.ok
@@ -58,6 +59,7 @@ class Nxrm2Configuration
     }
 
     @Override
+    @POST
     FormValidation doVerifyCredentials(@QueryParameter String serverUrl, @QueryParameter String credentialsId)
         throws IOException
     {

--- a/src/main/java/org/sonatype/nexus/ci/config/Nxrm3Configuration.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/config/Nxrm3Configuration.groovy
@@ -19,6 +19,7 @@ import hudson.Extension
 import hudson.util.FormValidation
 import org.kohsuke.stapler.DataBoundConstructor
 import org.kohsuke.stapler.QueryParameter
+import org.kohsuke.stapler.verb.POST
 
 import static hudson.util.FormValidation.error
 import static hudson.util.FormValidation.ok
@@ -80,6 +81,7 @@ class Nxrm3Configuration
     }
 
     @Override
+    @POST
     FormValidation doVerifyCredentials(@QueryParameter String serverUrl, @QueryParameter String credentialsId)
         throws IOException
     {

--- a/src/main/java/org/sonatype/nexus/ci/config/Nxrm3Configuration.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/config/Nxrm3Configuration.groovy
@@ -17,6 +17,7 @@ import com.sonatype.nexus.api.exception.RepositoryManagerException
 import groovy.util.logging.Log
 import hudson.Extension
 import hudson.util.FormValidation
+import jenkins.model.Jenkins
 import org.kohsuke.stapler.DataBoundConstructor
 import org.kohsuke.stapler.QueryParameter
 import org.kohsuke.stapler.verb.POST
@@ -85,6 +86,8 @@ class Nxrm3Configuration
     FormValidation doVerifyCredentials(@QueryParameter String serverUrl, @QueryParameter String credentialsId)
         throws IOException
     {
+      Jenkins.get().checkPermission(Jenkins.ADMINISTER)
+
       def repositories
       def badVersionMsg = ''
 


### PR DESCRIPTION
Nexus Platform plugin does not perform permission checks allowing user with Overall/Read permission to connect to an attacker-specified URL.

Two of the three endpoints also lead to a Credentials leaking due to the presence of the `credentialsId `parameter which can be used by an attacker to receive a request with username and password base64 encoded inside the headers as Basic Authentication.

Additionally, these HTTP endpoints do not require POST request, resulting in a cross-site request forgery (CSRF) vulnerability.

Culprit
[NxiqConfiguration.groovy#L126](https://github.com/jenkinsci/nexus-platform-plugin/blob/ba7b10f1c4cf3a712d2836ad66f5ed0d2047ad49/src/main/java/org/sonatype/nexus/ci/config/NxiqConfiguration.groovy#L126)
[Nxrm2Configuration.groovy#L61](https://github.com/jenkinsci/nexus-platform-plugin/blob/ba7b10f1c4cf3a712d2836ad66f5ed0d2047ad49/src/main/java/org/sonatype/nexus/ci/config/Nxrm2Configuration.groovy#L61)
[Nxrm3Configuration.groovy#L83](https://github.com/jenkinsci/nexus-platform-plugin/blob/ba7b10f1c4cf3a712d2836ad66f5ed0d2047ad49/src/main/java/org/sonatype/nexus/ci/config/Nxrm3Configuration.groovy#L83)

Recommendation
- [Protecting from CSRF](https://www.jenkins.io/doc/developer/security/form-validation/#protecting-from-csrf)
- [Checking Permission](https://www.jenkins.io/doc/developer/security/form-validation/#checking-permissions)

#### Links
Jira: https://sonatype.atlassian.net/browse/SEC-763
Build: https://jenkins.ci.sonatype.dev/job/integrations/job/jenkins/job/feature-snapshots/job/SEC-763-Vulnerabilities-Reported-by-Jenkins-Team/