### PR TITLE
CLM-28551 - Check Jenkins plugin compatibility with Jenkins version 2.426.1

### DIFF
--- a/Jenkinsfile.sonatype.extra-tests
+++ b/Jenkinsfile.sonatype.extra-tests
@@ -56,11 +56,11 @@ pipeline {
             }
           }
         }
-        stage('Jenkins 2.414.1 - Java 17') {
+        stage('Jenkins 2.426.1 - Java 17') {
           agent { label agentLabel }
           steps {
             runTests('OpenJDK 17',
-                '-Djenkins.version=2.414.1 -Djenkins.tools.bom.artifactId=bom-2.414.x -Djenkins.tools.bom.version=2401.v7a_d68f8d0b_09')
+                '-Djenkins.version=2.426.1 -Djenkins.tools.bom.artifactId=bom-2.426.x -Djenkins.tools.bom.version=2582.v830625dd636c')
           }
           post {
             always {

--- a/pom.xml
+++ b/pom.xml
@@ -277,6 +277,11 @@
       <artifactId>pipeline-model-definition</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-web</artifactId>
+      <version>5.3.28</version>
+    </dependency>
     <!-- End Jenkins plugins for testing -->
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -130,6 +130,13 @@
         <scope>import</scope>
         <type>pom</type>
       </dependency>
+      <!-- spring-web:5.3.29 is brought in by org.jenkinsci.plugins:pipeline-model-definition
+           but it is quarantined. Using 5.3.28 instead as it is an available version -->
+      <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-web</artifactId>
+        <version>5.3.28</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -276,11 +283,6 @@
       <groupId>org.jenkinsci.plugins</groupId>
       <artifactId>pipeline-model-definition</artifactId>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-web</artifactId>
-      <version>5.3.28</version>
     </dependency>
     <!-- End Jenkins plugins for testing -->
   </dependencies>

--- a/src/test/java/org/sonatype/nexus/ci/iq/PipelineSyntaxIntegrationTest.groovy
+++ b/src/test/java/org/sonatype/nexus/ci/iq/PipelineSyntaxIntegrationTest.groovy
@@ -108,13 +108,13 @@ class PipelineSyntaxIntegrationTest
       clicked.getFirstByXPath("//label[contains(text(),'${IqPolicyEvaluation_SelectApplication()}')]")
 
     and: 'advanced properties are available in the page (if not always visible)'
-      String xml = clicked.asXml()
-      xml.contains(Messages.IqPolicyEvaluation_ScanPatterns())    
-      xml.contains(Messages.IqPolicyEvaluation_ModuleExcludes())    
-      xml.contains(Messages.IqPolicyEvaluation_FailOnNetwork())    
-      xml.contains(Messages.IqPolicyEvaluation_JobSpecificCredentials())    
-      xml.contains('name="_.enableDebugLogging" type="checkbox"')
-      xml.contains(Messages.IqPolicyEvaluation_AdvancedProperties())    
+      String textContent = clicked.getDocumentElement().textContent
+      textContent.contains(Messages.IqPolicyEvaluation_ScanPatterns())
+      textContent.contains(Messages.IqPolicyEvaluation_ModuleExcludes())
+      textContent.contains(Messages.IqPolicyEvaluation_FailOnNetwork())
+      textContent.contains(Messages.IqPolicyEvaluation_JobSpecificCredentials())
+      textContent.contains('Enable debug')
+      textContent.contains(Messages.IqPolicyEvaluation_AdvancedProperties())
   }
 
   private HtmlOption selectPolicyEvaluation(WebClient client, WorkflowJob project) {


### PR DESCRIPTION
I also manually tested by running Jenkins Version 2.426.1 locally and installing the snapshot hpi.. I verified running a pipeline completed successfully.. 

https://sonatype.atlassian.net/browse/CLM-28551
https://jenkins.ci.sonatype.dev/job/integrations/job/jenkins/job/feature-snapshots/job/CLM-28551_Check_Jenkins_plugin_compatibility_with_Jenkins_version_2.426.1/