### PR TITLE
CLM-28746 - Use Jenkins InstanceId For Telemetry

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
     <enforcer.skip>true</enforcer.skip> <!-- TODO numerous requireUpperBoundDeps, some probably indicative of real problems -->
     <jvnet-localizer-plugin.version>1.23</jvnet-localizer-plugin.version>
     <forkCount>1</forkCount>
-    <nexus-platform-api.version>5.0.0-01</nexus-platform-api.version>
+    <nexus-platform-api.version>5.0.1-SNAPSHOT</nexus-platform-api.version>
 
     <buildsupport.version>36</buildsupport.version>
     <buildsupport.license-maven-plugin.version>4.1</buildsupport.license-maven-plugin.version>

--- a/src/main/java/org/sonatype/nexus/ci/config/GlobalNexusConfiguration.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/config/GlobalNexusConfiguration.groovy
@@ -12,6 +12,7 @@
  */
 package org.sonatype.nexus.ci.config
 
+import com.sonatype.insight.client.utils.InstanceIdProvider
 import hudson.Extension
 import hudson.model.Descriptor
 import jenkins.model.GlobalConfiguration
@@ -35,6 +36,7 @@ class GlobalNexusConfiguration
       instanceId = generateRandomId()
       save()
     }
+    InstanceIdProvider.preferredInstanceId = instanceId
   }
 
   @DataBoundConstructor

--- a/src/test/java/org/sonatype/nexus/ci/config/GlobalNexusConfigurationTest.groovy
+++ b/src/test/java/org/sonatype/nexus/ci/config/GlobalNexusConfigurationTest.groovy
@@ -12,6 +12,7 @@
  */
 package org.sonatype.nexus.ci.config
 
+import com.sonatype.insight.client.utils.InstanceIdProvider
 import org.junit.Rule
 import org.jvnet.hudson.test.JenkinsRule
 import org.jvnet.hudson.test.WithoutJenkins
@@ -43,6 +44,17 @@ class GlobalNexusConfigurationTest
 
     then:
       uuid1 == uuid2
+  }
+
+  def 'InstanceIdProvider#instanceId is set to Configuration#instanceId'() {
+    setup:
+    GlobalNexusConfiguration globalNexusConfiguration = GlobalNexusConfiguration.globalNexusConfiguration
+
+    when:
+    globalNexusConfiguration.load()
+
+    then:
+    globalNexusConfiguration.instanceId == InstanceIdProvider.instanceId
   }
 
   @WithoutJenkins


### PR DESCRIPTION
https://sonatype.atlassian.net/browse/CLM-28746
https://jenkins.ci.sonatype.dev/job/integrations/job/jenkins/job/feature-snapshots/job/CLM-28746_Use_Jenkins_Instance_Id_For_Telemetry/

When there are multiple instances of IQ is configured in Jenkins, there is still one `instanceId`. See below the configuration file found in `.jenkins` folder. The `instanceId` being used is: `c9765940a54f41b98c98eb8aab5e264f`. 

```
<?xml version='1.1' encoding='UTF-8'?>
<org.sonatype.nexus.ci.config.GlobalNexusConfiguration plugin="nexus-jenkins-plugin@3.19.1-SNAPSHOT">
  <nxrmConfigs/>
  <iqConfigs>
    <org.sonatype.nexus.ci.config.NxiqConfiguration>
      <id>nexusiq</id>
      <internalId>3735cfdb-6d66-4d98-9cc3-d26f142e8c05</internalId>
    </org.sonatype.nexus.ci.config.NxiqConfiguration>
    <org.sonatype.nexus.ci.config.NxiqConfiguration>
      <id>second-iq-server</id>
      <internalId>b7976d0a-0353-467b-bf01-1005e77614e0</internalId>
    </org.sonatype.nexus.ci.config.NxiqConfiguration>
  </iqConfigs>
  <instanceId>c9765940a54f41b98c98eb8aab5e264f</instanceId>
</org.sonatype.nexus.ci.config.GlobalNexusConfiguration>
```

I also configured an agent and an agent only has minimal configuration. I also verified the global `instanceId` is used even when an agent runs a pipeline. Below is the configuration for an agent:
```
<?xml version='1.1' encoding='UTF-8'?>
<slave>
  <name>my-node</name>
  <description></description>
  <remoteFS>/Users/home/my-jenkins-node</remoteFS>
  <numExecutors>1</numExecutors>
  <mode>NORMAL</mode>
  <retentionStrategy class="hudson.slaves.RetentionStrategy$Always"/>
  <launcher class="hudson.slaves.JNLPLauncher">
    <workDirSettings>
      <disabled>false</disabled>
      <internalDir>remoting</internalDir>
      <failIfWorkDirIsMissing>false</failIfWorkDirIsMissing>
    </workDirSettings>
    <webSocket>false</webSocket>
  </launcher>
  <label></label>
  <nodeProperties/>
</slave>
```

I tested uninstalling and installing the plugin again. The `instanceId` is retained. When uninstalling the plugin, the below is presented to the user in Jenkins
<img width="443" alt="Screenshot 2024-01-16 at 09 03 05" src="https://github.com/jenkinsci/nexus-platform-plugin/assets/1974123/fa917daa-9538-41f6-b7a3-f5b404bb7e80">

It is a a bit time consuming testing these changes. The plugin must be built locally and then installed to a running Jenkins instance locally. Then configure Jenkins plugin to your locally running IQ instance. Put a breakpoint in: https://github.com/sonatype/insight-brain/blob/main/insight-brain-service/src/main/java/com/sonatype/insight/brain/telemetry/TelemetrySender.java#L111 and verify the `instanceId` in telemetry is the `instanceId` you have in `.jenkins` folder `org.sonatype.nexus.ci.config.GlobalNexusConfiguration.xml` file. 

<img width="1118" alt="Screenshot 2024-01-16 at 11 24 10" src="https://github.com/jenkinsci/nexus-platform-plugin/assets/1974123/0deaa2de-f6cd-40f6-9817-35aff0baef41">


