### PR TITLE
INT-7963 - [FIX] Exclude Scan Patterns does not exclude correctly

### DIFF
--- a/src/main/java/org/sonatype/nexus/ci/iq/RemoteScanner.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/iq/RemoteScanner.groovy
@@ -98,8 +98,8 @@ class RemoteScanner
           def filesExcludes = scanPatterns.findAll { it.startsWith('!') }
               .collect { it.substring(1) }.join(',')
           def userFileExcludes = advancedProperties.getProperty("fileExcludes")
-          if (userFileExcludes) {
-            fileExcludes = userFileExcludes + ',' + fileExcludes 
+          if (userFileExcludes != null && !userFileExcludes.trim().isEmpty()) {
+            filesExcludes = userFileExcludes + ',' + filesExcludes
           }
           advancedProperties.setProperty("fileExcludes", filesExcludes)
         }

--- a/src/main/java/org/sonatype/nexus/ci/iq/RemoteScanner.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/iq/RemoteScanner.groovy
@@ -112,19 +112,13 @@ class RemoteScanner
     def directoryScanner = RemoteScannerFactory.getDirectoryScanner()
     def normalizedScanPatterns = scanPatterns ?: DEFAULT_SCAN_PATTERN
     def includeScanPatterns = normalizedScanPatterns.findAll{!it.startsWith(EXCLUDE_MARKER)}
-    def excludes = [] as List
-    for (pattern in normalizedScanPatterns) {
-      if (pattern.startsWith('!')) {
-        excludes.add(pattern.substring(1))
-      }
-    }
-    //def excludeScanPatterns = normalizedScanPatterns.findAll{it.startsWith(EXCLUDE_MARKER)}.collect{it.substring(1)}
+    def excludeScanPatterns = normalizedScanPatterns.findAll{it.startsWith(EXCLUDE_MARKER)}.collect{it.substring(1)}
     directoryScanner.setBasedir(workDir)
     directoryScanner.setIncludes(includeScanPatterns.toArray(new String[includeScanPatterns.size()]))
-    directoryScanner.setExcludes(excludes.toArray(new String[excludes.size()]))
+    directoryScanner.setExcludes(excludeScanPatterns.toArray(new String[excludeScanPatterns.size()]))
     directoryScanner.addDefaultExcludes()
     directoryScanner.scan()
-       return (directoryScanner.getIncludedDirectories() + directoryScanner.getIncludedFiles())
+    return (directoryScanner.getIncludedDirectories() + directoryScanner.getIncludedFiles())
         .collect { f -> new File(workDir, f) }
         .sort()
         .asImmutable()

--- a/src/main/java/org/sonatype/nexus/ci/iq/RemoteScanner.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/iq/RemoteScanner.groovy
@@ -94,21 +94,12 @@ class RemoteScanner
         targets.add(new File(pattern))
         targets = Collections.unmodifiableList(targets)
       } else {
-        def exclusions = scanPatterns.findAll { it.startsWith('!') }
-        log.info("[RemoteScanner-Jenkins] exclusions: {}", exclusions)
-        def excludePatterns = exclusions.collect { it.substring(1) }
-        log.info("[RemoteScanner-Jenkins] excludePatterns: {}", excludePatterns)
-        targets = targets.toList()
-        targets = targets.findAll { file ->
-          def fileName = file.name
-          def excluded = excludePatterns.any { pat ->
-            fileName.endsWith(pat)
-          }
-          !excluded
+        if (scanPatterns != null || !scanPatterns.isEmpty()) {
+          def filesExcludes = scanPatterns.findAll { it.startsWith('!') }
+              .collect { it.substring(1) }.join(',')
+          advancedProperties.setProperty("fileExcludes", filesExcludes)
         }
-
-        targets = Collections.unmodifiableList(targets)
-        log.info("[RemoteScanner-Jenkins] targets: {}", targets.toString())
+        log.debug("[RemoteScanner-Jenkins] fileExcludes: {}", advancedProperties.getProperty("fileExcludes"))
       }
     }
     def moduleIndices = getModuleIndices(workDirectory, moduleExcludes)

--- a/src/main/java/org/sonatype/nexus/ci/iq/RemoteScanner.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/iq/RemoteScanner.groovy
@@ -97,13 +97,11 @@ class RemoteScanner
         if (scanPatterns != null || !scanPatterns.isEmpty()) {
           def filesExcludes = scanPatterns.findAll { it.startsWith('!') }
               .collect { it.substring(1) }.join(',')
-          def userFileExcludes = advancedProperties.getProperty("fileExcludes")
-          if (userFileExcludes != null && !userFileExcludes.trim().isEmpty()) {
-            filesExcludes = userFileExcludes + ',' + filesExcludes
+          if (filesExcludes) {
+            advancedProperties.setProperty("fileExcludes", filesExcludes)
+            log.debug("[RemoteScanner-Jenkins] fileExcludes: {}", advancedProperties.getProperty("fileExcludes"))
           }
-          advancedProperties.setProperty("fileExcludes", filesExcludes)
         }
-        log.debug("[RemoteScanner-Jenkins] fileExcludes: {}", advancedProperties.getProperty("fileExcludes"))
       }
     }
     def moduleIndices = getModuleIndices(workDirectory, moduleExcludes)

--- a/src/main/java/org/sonatype/nexus/ci/iq/RemoteScanner.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/iq/RemoteScanner.groovy
@@ -99,8 +99,8 @@ class RemoteScanner
             filesExcludesSet.add(pattern.substring(1))
           }
       }
-      addAllFileExcludesToAdvancedProperties(filesExcludesSet)
     }
+    addAllFileExcludesToAdvancedProperties(filesExcludesSet)
 
     def moduleIndices = getModuleIndices(workDirectory, moduleExcludes)
     def scanResult = iqClient.scan(appId, proprietaryConfig, advancedProperties, targets, moduleIndices, workDirectory,

--- a/src/main/java/org/sonatype/nexus/ci/iq/RemoteScanner.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/iq/RemoteScanner.groovy
@@ -97,6 +97,10 @@ class RemoteScanner
         if (scanPatterns != null || !scanPatterns.isEmpty()) {
           def filesExcludes = scanPatterns.findAll { it.startsWith('!') }
               .collect { it.substring(1) }.join(',')
+          def userFileExcludes = advancedProperties.getProperty("fileExcludes")
+          if (userFileExcludes) {
+            fileExcludes = userFileExcludes + ',' + fileExcludes 
+          }
           advancedProperties.setProperty("fileExcludes", filesExcludes)
         }
         log.debug("[RemoteScanner-Jenkins] fileExcludes: {}", advancedProperties.getProperty("fileExcludes"))

--- a/src/main/java/org/sonatype/nexus/ci/iq/RemoteScanner.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/iq/RemoteScanner.groovy
@@ -33,6 +33,10 @@ class RemoteScanner
 
   public static final String EXCLUDE_MARKER = '!'
 
+  public static final String COMMA_CHAR = ','
+
+  public static final String FILE_EXCLUDES = "fileExcludes"
+
   private final String appId
 
   private final String stageId
@@ -140,24 +144,24 @@ class RemoteScanner
   }
 
   private boolean isAnExclusionPattern(String pattern) {
-    pattern.startsWith('!')
+    pattern.startsWith(EXCLUDE_MARKER)
   }
 
   private void addAllFileExcludesToAdvancedProperties(Set filesExcludesSet) {
-    def userFileExcludes = advancedProperties != null ? advancedProperties.getProperty("fileExcludes") : null
+    def userFileExcludes = advancedProperties != null ? advancedProperties.getProperty(FILE_EXCLUDES) : null
     if (userFileExcludes) {
       if (userFileExcludes.length() > 0) {
-        filesExcludesSet.addAll(userFileExcludes.split(','))
+        filesExcludesSet.addAll(userFileExcludes.split(COMMA_CHAR))
       } else {
         filesExcludesSet.addAll(userFileExcludes)
       }
     }
 
-    def filesExcludes = filesExcludesSet.join(',')
+    def filesExcludes = filesExcludesSet.join(COMMA_CHAR)
 
     if (filesExcludes) {
-      advancedProperties.setProperty("fileExcludes", filesExcludes)
-      log.debug("[RemoteScanner-Jenkins] fileExcludes: {}", advancedProperties.getProperty("fileExcludes"))
+      advancedProperties.setProperty(FILE_EXCLUDES, filesExcludes)
+      log.debug("[RemoteScanner-Jenkins] fileExcludes: {}", advancedProperties.getProperty(FILE_EXCLUDES))
     }
   }
 

--- a/src/main/java/org/sonatype/nexus/ci/iq/RemoteScanner.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/iq/RemoteScanner.groovy
@@ -99,9 +99,8 @@ class RemoteScanner
             filesExcludesSet.add(pattern.substring(1))
           }
       }
+      addAllFileExcludesToAdvancedProperties(filesExcludesSet)
     }
-
-    addAllFileExcludesToAdvancedProperties(filesExcludesSet)
 
     def moduleIndices = getModuleIndices(workDirectory, moduleExcludes)
     def scanResult = iqClient.scan(appId, proprietaryConfig, advancedProperties, targets, moduleIndices, workDirectory,
@@ -145,12 +144,17 @@ class RemoteScanner
   }
 
   private void addAllFileExcludesToAdvancedProperties(Set filesExcludesSet) {
-    def userFileExcludes = advancedProperties.getProperty("fileExcludes")
+    def userFileExcludes = advancedProperties != null ? advancedProperties.getProperty("fileExcludes") : null
     if (userFileExcludes) {
-      filesExcludesSet.addAll(userFileExcludes.split(','))
+      if (userFileExcludes.length() > 0) {
+        filesExcludesSet.addAll(userFileExcludes.split(','))
+      } else {
+        filesExcludesSet.addAll(userFileExcludes)
+      }
     }
 
     def filesExcludes = filesExcludesSet.join(',')
+
     if (filesExcludes) {
       advancedProperties.setProperty("fileExcludes", filesExcludes)
       log.debug("[RemoteScanner-Jenkins] fileExcludes: {}", advancedProperties.getProperty("fileExcludes"))

--- a/src/test/java/org/sonatype/nexus/ci/iq/RemoteScannerTest.groovy
+++ b/src/test/java/org/sonatype/nexus/ci/iq/RemoteScannerTest.groovy
@@ -33,6 +33,9 @@ class RemoteScannerTest
   @Shared
   ProprietaryConfig proprietaryConfig = new ProprietaryConfig([], [])
 
+  @Shared
+  Properties advancedProperties = new Properties()
+
   Logger log
   InternalIqClient iqClient
   DirectoryScanner directoryScanner
@@ -242,5 +245,23 @@ class RemoteScannerTest
     1 * directoryScanner.setExcludes(*_) >> { arguments ->
       assert arguments[0] == ['*.zip','*.tar']
     }
+  }
+
+  def 'RemoteScanner passes exclusion patterns to IqClient'() {
+    setup:
+      def workspaceFile = new File('/file/path')
+      final RemoteScanner remoteScanner = new RemoteScanner('appId', 'stageId', ['*.jar','!*.zip','*.war','!*.tar'], [], new FilePath(workspaceFile),
+          proprietaryConfig, log, 'instanceId', advancedProperties, null)
+      directoryScanner.getIncludedDirectories() >> []
+      directoryScanner.getIncludedFiles() >> []
+
+    when:
+      remoteScanner.call()
+
+    then:
+      iqClient.scan(*_) >> { arguments ->
+        assert arguments[2] == ['fileExcludes':'*.zip,*.tar']
+        new ScanResult(null, new File('file'))
+      }
   }
 }

--- a/src/test/java/org/sonatype/nexus/ci/iq/RemoteScannerTest.groovy
+++ b/src/test/java/org/sonatype/nexus/ci/iq/RemoteScannerTest.groovy
@@ -250,6 +250,7 @@ class RemoteScannerTest
   def 'RemoteScanner passes exclusion patterns to IqClient'() {
     setup:
       def workspaceFile = new File('/file/path')
+      advancedProperties.setProperty('fileExcludes', '*.ear')
       final RemoteScanner remoteScanner = new RemoteScanner('appId', 'stageId', ['*.jar','!*.zip','*.war','!*.tar'], [], new FilePath(workspaceFile),
           proprietaryConfig, log, 'instanceId', advancedProperties, null)
       directoryScanner.getIncludedDirectories() >> []
@@ -260,7 +261,11 @@ class RemoteScannerTest
 
     then:
       iqClient.scan(*_) >> { arguments ->
-        assert arguments[2] == ['fileExcludes':'*.zip,*.tar']
+        def fileExcludesList = arguments[2]['fileExcludes'].split(',').toList()
+        def expectedFilesExcludes = ['*.zip','*.tar', '*.ear']
+        assert fileExcludesList.containsAll(expectedFilesExcludes)
+        assert fileExcludesList.size() == expectedFilesExcludes.size()
+
         new ScanResult(null, new File('file'))
       }
   }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Jira ticket: https://sonatype.atlassian.net/browse/INT-7963
CI: https://jenkins.ci.sonatype.dev/job/integrations/job/jenkins/job/feature-snapshots/job/INT-7963_Exclude_Scan_Patterns_doesnt_work/lastBuild/


The purpose of this PR is to add a fix for the use of file exclusion patterns. The files to exclude are passed as parameters with a "!" at the beginning. 
For example:

Example 1: 
```
stage('build') {
        nexusPolicyEvaluation iqStage: 'build', iqApplication: 'app',
        iqScanPatterns: [[scanPattern: '**'], [scanPattern: '!*.zip']]
        failBuildOnNetworkError: true
}
```

Example 2:

<img width="1050" alt="image" src="https://github.com/jenkinsci/nexus-platform-plugin/assets/32085323/5357f1ee-8159-4af7-9288-5b8b2ebe54a8">




### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
