### PR TITLE
In order to prevent IllegalStateException in callflow options, avoid calling the agent-node-side code from master node.

### DIFF
--- a/src/main/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorUtil.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorUtil.groovy
@@ -133,9 +133,6 @@ class IqPolicyEvaluatorUtil
           callflowOptions = null
         }
 
-        loggerBridge.println("********************************")
-        loggerBridge.println(callflowOptions)
-
         evaluationResult = iqClient.evaluateApplication(
             applicationId,
             iqStage,

--- a/src/main/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorUtil.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorUtil.groovy
@@ -122,14 +122,15 @@ class IqPolicyEvaluatorUtil
 
           callflowOptions = makeCallflowOptions(
               callflowConfiguration,
-              remoteScanner,
-              workDirectory,
-              envVars,
+              remoteScanResult.getOriginalRemoteTargetsAbsolutePaths(),
               iqPolicyEvaluator.iqScanPatterns
           )
         } else {
           callflowOptions = null
         }
+
+        loggerBridge.println("********************************")
+        loggerBridge.println(callflowOptions)
 
         evaluationResult = iqClient.evaluateApplication(
             applicationId,
@@ -213,18 +214,10 @@ class IqPolicyEvaluatorUtil
 
   private static CallflowOptions makeCallflowOptions(
       final CallflowConfiguration callflowConfiguration,
-      final RemoteScanner remoteScanner,
-      final File workdir,
-      final EnvVars envVars,
+      final List<String> targets,
       final List<ScanPattern> iqScanPatterns)
   {
     if (callflowConfiguration == null) {
-      final List<String> expandedPatterns = getScanPatterns(iqScanPatterns, envVars)
-      final List<String> targets = remoteScanner.getScanTargets(workdir, expandedPatterns)
-          .collect {
-            return it.getAbsolutePath()
-          }
-
       // defaults to using same targets as original iq scan, when enabled but no additional config passed
       return new CallflowOptions(targets, null, null)
     } else {
@@ -233,11 +226,6 @@ class IqPolicyEvaluatorUtil
         // defaults to using same targets as original iq scan, when no patterns passed with additional config
         patterns = iqScanPatterns
       }
-
-      final List<String> expandedPatterns = getScanPatterns(patterns, envVars)
-
-      final List<String> targets = remoteScanner.getScanTargets(workdir, expandedPatterns)
-          .collect { it.getAbsolutePath() }
 
       final Properties addtionalConfiguration = new Properties()
       if (callflowConfiguration.getAdditionalConfiguration() != null) {

--- a/src/main/java/org/sonatype/nexus/ci/iq/RemoteScanResult.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/iq/RemoteScanResult.groovy
@@ -24,10 +24,21 @@ class RemoteScanResult
 
   private final FilePath filePath
 
-  RemoteScanResult(Scan scan, FilePath filePath) {
+  private final List<String> originalRemoteTargetsAbsolutePaths
+
+  RemoteScanResult(Scan scan, FilePath filePath, List<String> originalRemoteTargetsAbsolutePaths) {
     this.filePath = filePath
     this.scan = scan
+    this.originalRemoteTargetsAbsolutePaths = originalRemoteTargetsAbsolutePaths
   }
+
+  /**
+   * The list of remote target file absolute paths, used by callflow options.
+   * @return a list of remote target file absolute paths
+   */
+   List<File> getOriginalRemoteTargetsAbsolutePaths() {
+    return originalRemoteTargetsAbsolutePaths
+   }
 
   /**
    * create a copy as a ScanResult with a local copy of the scan file

--- a/src/main/java/org/sonatype/nexus/ci/iq/RemoteScanResult.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/iq/RemoteScanResult.groovy
@@ -36,7 +36,7 @@ class RemoteScanResult
    * The list of remote target file absolute paths, used by callflow options.
    * @return a list of remote target file absolute paths
    */
-   List<File> getOriginalRemoteTargetsAbsolutePaths() {
+   List<String> getOriginalRemoteTargetsAbsolutePaths() {
     return originalRemoteTargetsAbsolutePaths
    }
 

--- a/src/main/java/org/sonatype/nexus/ci/iq/RemoteScanner.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/iq/RemoteScanner.groovy
@@ -88,6 +88,7 @@ class RemoteScanner
     InternalIqClient iqClient = IqClientFactory.getIqLocalClient(log, instanceId)
     def workDirectory = new File(workspace.getRemote())
     def targets = getScanTargets(workDirectory, scanPatterns)
+    def originalRemoteTargetsAbsolutePaths = targets.collect { return it.getAbsolutePath() }
     for (String pattern : scanPatterns) {
       if (pattern.startsWith(CONTAINER)) {
         targets = targets.toList()
@@ -98,7 +99,7 @@ class RemoteScanner
     def moduleIndices = getModuleIndices(workDirectory, moduleExcludes)
     def scanResult = iqClient.scan(appId, proprietaryConfig, advancedProperties, targets, moduleIndices, workDirectory,
         envVars, licensedFeatures)
-    return new RemoteScanResult(scanResult.scan, new FilePath(scanResult.scanFile))
+    return new RemoteScanResult(scanResult.scan, new FilePath(scanResult.scanFile), originalRemoteTargetsAbsolutePaths)
   }
 
   List<File> getScanTargets(final File workDir, final List<String> scanPatterns) {

--- a/src/test/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorTest.groovy
+++ b/src/test/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorTest.groovy
@@ -717,13 +717,14 @@ class IqPolicyEvaluatorTest
       iqClient.getProprietaryConfigForApplicationEvaluation('appId') >> proprietaryConfig
       RemoteScannerFactory.getRemoteScanner(*_) >> remoteScanner
       channel.call(_) >> remoteScanResult
+      remoteScanResult.getOriginalRemoteTargetsAbsolutePaths() >> defaultCallflowOptions.scanTargets
 
     when:
       getBuildStepForCallflowTests(true, null)
           .perform((AbstractBuild) run, launcher, Mock(BuildListener))
 
     then: 'evaluates the results using default callflow options'
-      1 * remoteScanner.getScanTargets(_, _) >> [pathReturnedByExpandingIqScanPatterns]
+      1 * remoteScanResult.getOriginalRemoteTargetsAbsolutePaths()
       1 * iqClient.evaluateApplication('appId', 'stage', scanResult, _, {
         it.scanTargets == defaultCallflowOptions.scanTargets &&
             it.namespaces == null &&
@@ -751,6 +752,7 @@ class IqPolicyEvaluatorTest
       iqClient.getProprietaryConfigForApplicationEvaluation('appId') >> proprietaryConfig
       RemoteScannerFactory.getRemoteScanner(*_) >> remoteScanner
       channel.call(_) >> remoteScanResult
+      remoteScanResult.getOriginalRemoteTargetsAbsolutePaths() >> expectedScanTargets
 
     when:
       getBuildStepForCallflowTests(
@@ -762,7 +764,7 @@ class IqPolicyEvaluatorTest
       ).perform((AbstractBuild) run, launcher, Mock(BuildListener))
 
     then: 'evaluates the results using default callflow options'
-      1 * remoteScanner.getScanTargets(*_) >> [new File("some-path-1"), new File('some-path-2')]
+      1 * remoteScanResult.getOriginalRemoteTargetsAbsolutePaths()
       1 * iqClient.evaluateApplication('appId', 'stage', scanResult, _, {
         it.scanTargets == expectedScanTargets &&
             it.namespaces == expectedNamespaces &&

--- a/src/test/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorTest.groovy
+++ b/src/test/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorTest.groovy
@@ -725,7 +725,7 @@ class IqPolicyEvaluatorTest
 
     then: 'evaluates the results using default callflow options'
       // Retrieve results only because callflow uses the same pattern as IQ scan.
-      1 * remoteScanResult.getOriginalRemoteTargetsAbsolutePaths()
+      1 * remoteScanResult.getOriginalRemoteTargetsAbsolutePaths() >> defaultCallflowOptions.scanTargets
       1 * iqClient.evaluateApplication('appId', 'stage', scanResult, _, {
         it.scanTargets == defaultCallflowOptions.scanTargets &&
             it.namespaces == null &&
@@ -766,7 +766,7 @@ class IqPolicyEvaluatorTest
 
     then: 'evaluates the results using default callflow options'
       // Retrieve results twice, once for IQ scan, once for the callflow-specific pattern.
-      2 * remoteScanResult.getOriginalRemoteTargetsAbsolutePaths()
+      2 * remoteScanResult.getOriginalRemoteTargetsAbsolutePaths() >> expectedScanTargets
       1 * iqClient.evaluateApplication('appId', 'stage', scanResult, _, {
         it.scanTargets == expectedScanTargets &&
             it.namespaces == expectedNamespaces &&

--- a/src/test/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorTest.groovy
+++ b/src/test/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorTest.groovy
@@ -724,6 +724,7 @@ class IqPolicyEvaluatorTest
           .perform((AbstractBuild) run, launcher, Mock(BuildListener))
 
     then: 'evaluates the results using default callflow options'
+      // Retrieve results only because callflow uses the same pattern as IQ scan.
       1 * remoteScanResult.getOriginalRemoteTargetsAbsolutePaths()
       1 * iqClient.evaluateApplication('appId', 'stage', scanResult, _, {
         it.scanTargets == defaultCallflowOptions.scanTargets &&
@@ -764,7 +765,8 @@ class IqPolicyEvaluatorTest
       ).perform((AbstractBuild) run, launcher, Mock(BuildListener))
 
     then: 'evaluates the results using default callflow options'
-      1 * remoteScanResult.getOriginalRemoteTargetsAbsolutePaths()
+      // Retrieve results twice, once for IQ scan, once for the callflow-specific pattern.
+      2 * remoteScanResult.getOriginalRemoteTargetsAbsolutePaths()
       1 * iqClient.evaluateApplication('appId', 'stage', scanResult, _, {
         it.scanTargets == expectedScanTargets &&
             it.namespaces == expectedNamespaces &&

--- a/src/test/java/org/sonatype/nexus/ci/iq/RemoteScanResultTest.groovy
+++ b/src/test/java/org/sonatype/nexus/ci/iq/RemoteScanResultTest.groovy
@@ -32,7 +32,7 @@ class RemoteScanResultTest extends Specification
     and: 'a scan'
       final Scan scan = Mock()
     and: 'a new remote scan result wrapped around the scan and agent file'
-      final remoteScanResult = new RemoteScanResult(scan, filePath)
+      final remoteScanResult = new RemoteScanResult(scan, filePath, new ArrayList<String>())
     expect: 'we can make a local copy of the result'
       final scanResult = remoteScanResult.copyToLocalScanResult()
       scanResult.scan == scan


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Piggyback remote scans to get callflow target info from the same roundtrip. This way we can avoid calling the same method again from master node, which would potentially cause IllegalStateException.

https://sonatype.atlassian.net/jira/software/c/projects/SDEV/boards/214?selectedIssue=SDEV-1117
### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
