### PR TITLE
SDEV-1117: Make sure target resolution always happens from within an MasterToSlaveCallable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,6 +141,12 @@
         <artifactId>spring-web</artifactId>
         <version>5.3.28</version>
       </dependency>
+      <!-- transitive dependency of jenkins-core. Pinned down to avoid: CVE-2023-34034 and CVE-2023-20862 -->
+      <dependency>
+        <groupId>org.springframework.security</groupId>
+        <artifactId>spring-security-web</artifactId>
+        <version>5.8.4</version>
+      </dependency>
       <!-- Override transitive commons-compress and use latest available due to Violations -->
       <dependency>
         <groupId>org.apache.commons</groupId>

--- a/src/main/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorUtil.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorUtil.groovy
@@ -107,7 +107,8 @@ class IqPolicyEvaluatorUtil
                 envVars)
         def repositoryUrl = launcher.getChannel().call(repositoryUrlFinder)
         if (repositoryUrl != null) {
-          def repositoryPath = Paths.get(workspace.getRemote(),".git").toString()
+          def repositoryPath = Paths.get(workspace.getRemote(), '.git').toString()
+
           iqClient.addOrUpdateSourceControl(applicationId, repositoryUrl, repositoryPath)
         }
 
@@ -215,7 +216,6 @@ class IqPolicyEvaluatorUtil
   private static CallflowOptions makeCallflowOptions(
       final Launcher launcher,
       final CallflowConfiguration callflowConfiguration,
-      final RemoteScanner remoteScanner,
       final File workdir,
       final EnvVars envVars,
       final List<ScanPattern> iqScanPatterns)

--- a/src/main/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorUtil.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorUtil.groovy
@@ -121,6 +121,7 @@ class IqPolicyEvaluatorUtil
           CallflowConfiguration callflowConfiguration = iqPolicyEvaluator.getCallflowConfiguration()
 
           callflowOptions = makeCallflowOptions(
+              launcher,
               callflowConfiguration,
               remoteScanner,
               workDirectory,
@@ -212,6 +213,7 @@ class IqPolicyEvaluatorUtil
   }
 
   private static CallflowOptions makeCallflowOptions(
+      final Launcher launcher,
       final CallflowConfiguration callflowConfiguration,
       final RemoteScanner remoteScanner,
       final File workdir,
@@ -220,10 +222,8 @@ class IqPolicyEvaluatorUtil
   {
     if (callflowConfiguration == null) {
       final List<String> expandedPatterns = getScanPatterns(iqScanPatterns, envVars)
-      final List<String> targets = remoteScanner.getScanTargets(workdir, expandedPatterns)
-          .collect {
-            return it.getAbsolutePath()
-          }
+      final RemoteFileResolver remoteFileResolver = new RemoteFileResolver(workdir, expandedPatterns)
+      final List<String> targets = launcher.getChannel().call(remoteFileResolver)
 
       // defaults to using same targets as original iq scan, when enabled but no additional config passed
       return new CallflowOptions(targets, null, null)
@@ -235,9 +235,8 @@ class IqPolicyEvaluatorUtil
       }
 
       final List<String> expandedPatterns = getScanPatterns(patterns, envVars)
-
-      final List<String> targets = remoteScanner.getScanTargets(workdir, expandedPatterns)
-          .collect { it.getAbsolutePath() }
+      final RemoteFileResolver remoteFileResolver = new RemoteFileResolver(workdir, expandedPatterns)
+      final List<String> targets = launcher.getChannel().call(remoteFileResolver)
 
       final Properties addtionalConfiguration = new Properties()
       if (callflowConfiguration.getAdditionalConfiguration() != null) {

--- a/src/main/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorUtil.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorUtil.groovy
@@ -124,7 +124,6 @@ class IqPolicyEvaluatorUtil
           callflowOptions = makeCallflowOptions(
               launcher,
               callflowConfiguration,
-              remoteScanner,
               workDirectory,
               envVars,
               iqPolicyEvaluator.iqScanPatterns

--- a/src/main/java/org/sonatype/nexus/ci/iq/RemoteFileResolver.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/iq/RemoteFileResolver.groovy
@@ -20,7 +20,7 @@ class RemoteFileResolver
   private final File workDir;
   private final List<String> scanPatterns;
 
-  RemoteFileResolver(final File workDir,final List<String> scanPatterns) {
+  RemoteFileResolver(final File workDir, final List<String> scanPatterns) {
     this.workDir = workDir
     this.scanPatterns = scanPatterns
   }

--- a/src/main/java/org/sonatype/nexus/ci/iq/RemoteFileResolver.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/iq/RemoteFileResolver.groovy
@@ -1,4 +1,16 @@
-package org.sonatype.nexus.ci.iq
+/*
+ * Copyright (c) 2016-present Sonatype, Inc. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+ package org.sonatype.nexus.ci.iq
 
 import jenkins.security.MasterToSlaveCallable
 

--- a/src/main/java/org/sonatype/nexus/ci/iq/RemoteFileResolver.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/iq/RemoteFileResolver.groovy
@@ -1,0 +1,23 @@
+package org.sonatype.nexus.ci.iq
+
+import jenkins.security.MasterToSlaveCallable
+
+class RemoteFileResolver
+    extends MasterToSlaveCallable<List<String>, RuntimeException>
+{
+  private final File workDir;
+  private final List<String> scanPatterns;
+
+  RemoteFileResolver(final File workDir,final List<String> scanPatterns) {
+    this.workDir = workDir
+    this.scanPatterns = scanPatterns
+  }
+
+  @Override
+  List<String> call() throws RuntimeException {
+    return ScanPatternUtil.getScanTargets(workDir, scanPatterns)
+        .collect {
+          return it.getAbsolutePath()
+        }
+  }
+}

--- a/src/main/java/org/sonatype/nexus/ci/iq/RemoteScanner.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/iq/RemoteScanner.groovy
@@ -23,15 +23,10 @@ import org.slf4j.Logger
 class RemoteScanner
     extends MasterToSlaveCallable<RemoteScanResult, RuntimeException>
 {
-  static final List<String> DEFAULT_SCAN_PATTERN =
-      ['**/*.jar', '**/*.war', '**/*.ear', '**/*.zip', '**/*.tar.gz']
-
   static final List<String> DEFAULT_MODULE_INCLUDES =
       ['**/sonatype-clm/module.xml', '**/nexus-iq/module.xml']
 
   public static final String CONTAINER = 'container:'
-
-  public static final String EXCLUDE_MARKER = '!'
 
   private final String appId
 
@@ -87,7 +82,7 @@ class RemoteScanner
 
     InternalIqClient iqClient = IqClientFactory.getIqLocalClient(log, instanceId)
     def workDirectory = new File(workspace.getRemote())
-    def targets = getScanTargets(workDirectory, scanPatterns)
+    def targets = ScanPatternUtil.getScanTargets(workDirectory, scanPatterns)
     for (String pattern : scanPatterns) {
       if (pattern.startsWith(CONTAINER)) {
         targets = targets.toList()
@@ -99,22 +94,6 @@ class RemoteScanner
     def scanResult = iqClient.scan(appId, proprietaryConfig, advancedProperties, targets, moduleIndices, workDirectory,
         envVars, licensedFeatures)
     return new RemoteScanResult(scanResult.scan, new FilePath(scanResult.scanFile))
-  }
-
-  List<File> getScanTargets(final File workDir, final List<String> scanPatterns) {
-    def directoryScanner = RemoteScannerFactory.getDirectoryScanner()
-    def normalizedScanPatterns = scanPatterns ?: DEFAULT_SCAN_PATTERN
-    def includeScanPatterns = normalizedScanPatterns.findAll{!it.startsWith(EXCLUDE_MARKER)}
-    def excludeScanPatterns = normalizedScanPatterns.findAll{it.startsWith(EXCLUDE_MARKER)}.collect{it.substring(1)}
-    directoryScanner.setBasedir(workDir)
-    directoryScanner.setIncludes(includeScanPatterns.toArray(new String[includeScanPatterns.size()]))
-    directoryScanner.setExcludes(excludeScanPatterns.toArray(new String[excludeScanPatterns.size()]))
-    directoryScanner.addDefaultExcludes()
-    directoryScanner.scan()
-    return (directoryScanner.getIncludedDirectories() + directoryScanner.getIncludedFiles())
-        .collect { f -> new File(workDir, f) }
-        .sort()
-        .asImmutable()
   }
 
   List<File> getModuleIndices(final File workDirectory, final List<String> moduleExcludes) {

--- a/src/main/java/org/sonatype/nexus/ci/iq/ScanPatternUtil.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/iq/ScanPatternUtil.groovy
@@ -1,0 +1,26 @@
+package org.sonatype.nexus.ci.iq
+
+class ScanPatternUtil
+{
+  static final List<String> DEFAULT_SCAN_PATTERN =
+      ['**/*.jar', '**/*.war', '**/*.ear', '**/*.zip', '**/*.tar.gz']
+
+  public static final String EXCLUDE_MARKER = '!'
+
+  // Warning: Only use this in the context of a MasterToSlaveCallable
+  static List<File> getScanTargets(final File workDir, final List<String> scanPatterns) {
+    def directoryScanner = RemoteScannerFactory.getDirectoryScanner()
+    def normalizedScanPatterns = scanPatterns ?: DEFAULT_SCAN_PATTERN
+    def includeScanPatterns = normalizedScanPatterns.findAll{!it.startsWith(EXCLUDE_MARKER)}
+    def excludeScanPatterns = normalizedScanPatterns.findAll{it.startsWith(EXCLUDE_MARKER)}.collect{it.substring(1)}
+    directoryScanner.setBasedir(workDir)
+    directoryScanner.setIncludes(includeScanPatterns.toArray(new String[includeScanPatterns.size()]))
+    directoryScanner.setExcludes(excludeScanPatterns.toArray(new String[excludeScanPatterns.size()]))
+    directoryScanner.addDefaultExcludes()
+    directoryScanner.scan()
+    return (directoryScanner.getIncludedDirectories() + directoryScanner.getIncludedFiles())
+        .collect { f -> new File(workDir, f) }
+        .sort()
+        .asImmutable()
+  }
+}

--- a/src/main/java/org/sonatype/nexus/ci/iq/ScanPatternUtil.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/iq/ScanPatternUtil.groovy
@@ -1,5 +1,6 @@
 package org.sonatype.nexus.ci.iq
 
+@SuppressWarnings(['AbcMetric'])
 class ScanPatternUtil
 {
   static final List<String> DEFAULT_SCAN_PATTERN =

--- a/src/main/java/org/sonatype/nexus/ci/iq/ScanPatternUtil.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/iq/ScanPatternUtil.groovy
@@ -1,3 +1,15 @@
+/*
+ * Copyright (c) 2016-present Sonatype, Inc. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
 package org.sonatype.nexus.ci.iq
 
 @SuppressWarnings(['AbcMetric'])

--- a/src/test/java/org/sonatype/nexus/ci/iq/RemoteScannerTest.groovy
+++ b/src/test/java/org/sonatype/nexus/ci/iq/RemoteScannerTest.groovy
@@ -150,23 +150,6 @@ class RemoteScannerTest
       'Base Directory'      | 5             | new File('/file/path')
   }
 
-  def 'Uses default scan patterns when patterns not set'() {
-    setup:
-      def workspaceFile = new File('/file/path')
-      final RemoteScanner remoteScanner = new RemoteScanner('appId', 'stageId', [], [], new FilePath(workspaceFile),
-          proprietaryConfig, log, 'instanceId', null, null)
-      directoryScanner.getIncludedDirectories() >> []
-      directoryScanner.getIncludedFiles() >> []
-
-    when:
-      remoteScanner.getScanTargets(workspaceFile, [])
-
-    then:
-      1 * directoryScanner.setIncludes(*_) >> { arguments ->
-        assert arguments[0] == RemoteScanner.DEFAULT_SCAN_PATTERN
-      }
-  }
-
   def 'Uses default modules for includes'() {
     setup:
       def workspaceFile = new File('/file/path')
@@ -200,47 +183,5 @@ class RemoteScannerTest
       1 * directoryScanner.setExcludes(*_) >> { arguments ->
         assert arguments[0] == moduleExcludes
       }
-  }
-
-
-  def 'Uses no excludes by default'() {
-    setup:
-    def workspaceFile = new File('/file/path')
-    final RemoteScanner remoteScanner = new RemoteScanner('appId', 'stageId', ['*.jar'], [], new FilePath(workspaceFile),
-            proprietaryConfig, log, 'instanceId', null, null)
-    directoryScanner.getIncludedDirectories() >> []
-    directoryScanner.getIncludedFiles() >> []
-
-    when:
-    remoteScanner.getScanTargets(workspaceFile, ['*.jar'])
-
-    then:
-    1 * directoryScanner.setIncludes(*_) >> { arguments ->
-      assert arguments[0] == ['*.jar']
-    }
-    1 * directoryScanner.setExcludes(*_) >> { arguments ->
-      assert arguments[0] == []
-    }
-  }
-
-
-  def 'Pass excludes to directory scanner'() {
-    setup:
-    def workspaceFile = new File('/file/path')
-    final RemoteScanner remoteScanner = new RemoteScanner('appId', 'stageId', ['*.jar','!*.zip','*.war','!*.tar'], [], new FilePath(workspaceFile),
-            proprietaryConfig, log, 'instanceId', null, null)
-    directoryScanner.getIncludedDirectories() >> []
-    directoryScanner.getIncludedFiles() >> []
-
-    when:
-    remoteScanner.getScanTargets(workspaceFile, ['*.jar','!*.zip','*.war','!*.tar'])
-
-    then:
-    1 * directoryScanner.setIncludes(*_) >> { arguments ->
-      assert arguments[0] == ['*.jar','*.war']
-    }
-    1 * directoryScanner.setExcludes(*_) >> { arguments ->
-      assert arguments[0] == ['*.zip','*.tar']
-    }
   }
 }

--- a/src/test/java/org/sonatype/nexus/ci/iq/ScanPatternUtilTest.groovy
+++ b/src/test/java/org/sonatype/nexus/ci/iq/ScanPatternUtilTest.groovy
@@ -1,0 +1,69 @@
+package org.sonatype.nexus.ci.iq
+
+import org.codehaus.plexus.util.DirectoryScanner
+import spock.lang.Specification
+import spock.util.mop.ConfineMetaClassChanges
+
+@ConfineMetaClassChanges([IqClientFactory])
+class ScanPatternUtilTest
+  extends Specification
+{
+  DirectoryScanner directoryScanner
+
+  def setup() {
+    GroovyMock(RemoteScannerFactory, global: true)
+    directoryScanner = Mock()
+    RemoteScannerFactory.getDirectoryScanner() >> directoryScanner
+  }
+
+  def 'Uses default scan patterns when patterns not set'() {
+    setup:
+      def workspaceFile = new File('/file/path')
+      directoryScanner.getIncludedDirectories() >> []
+      directoryScanner.getIncludedFiles() >> []
+
+    when:
+      ScanPatternUtil.getScanTargets(workspaceFile, [])
+
+    then:
+      1 * directoryScanner.setIncludes(*_) >> { arguments ->
+        assert arguments[0] == ScanPatternUtil.DEFAULT_SCAN_PATTERN
+      }
+  }
+
+  def 'Uses no excludes by default'() {
+    setup:
+      def workspaceFile = new File('/file/path')
+      directoryScanner.getIncludedDirectories() >> []
+      directoryScanner.getIncludedFiles() >> []
+
+    when:
+      ScanPatternUtil.getScanTargets(workspaceFile, ['*.jar'])
+
+    then:
+      1 * directoryScanner.setIncludes(*_) >> { arguments ->
+        assert arguments[0] == ['*.jar']
+      }
+      1 * directoryScanner.setExcludes(*_) >> { arguments ->
+        assert arguments[0] == []
+      }
+  }
+
+  def 'Pass excludes to directory scanner'() {
+    setup:
+      def workspaceFile = new File('/file/path')
+      directoryScanner.getIncludedDirectories() >> []
+      directoryScanner.getIncludedFiles() >> []
+
+    when:
+      ScanPatternUtil.getScanTargets(workspaceFile, ['*.jar','!*.zip','*.war','!*.tar'])
+
+    then:
+      1 * directoryScanner.setIncludes(*_) >> { arguments ->
+        assert arguments[0] == ['*.jar','*.war']
+      }
+      1 * directoryScanner.setExcludes(*_) >> { arguments ->
+        assert arguments[0] == ['*.zip','*.tar']
+      }
+  }
+}

--- a/src/test/java/org/sonatype/nexus/ci/iq/ScanPatternUtilTest.groovy
+++ b/src/test/java/org/sonatype/nexus/ci/iq/ScanPatternUtilTest.groovy
@@ -1,3 +1,15 @@
+/*
+ * Copyright (c) 2016-present Sonatype, Inc. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
 package org.sonatype.nexus.ci.iq
 
 import org.codehaus.plexus.util.DirectoryScanner


### PR DESCRIPTION
https://sonatype.atlassian.net/browse/SDEV-1117

For callflow we will either reuse the scan patterns provied for the traditional scan or alternatively make use of an ovveride. In either case before hadning off to dependencies to do the actual work the patterns need to be resolved to file targets.

Because jenkins manages a cluster this needs to be done from the right context. I have refactored out the actuall file resolution logic to make it easier to re-use and created a new class that extends MasterToSlaveCallable so that we can leverage the logic from the right place.

The orginal place where this logic was used inside RemoteScanner was already within a MasterToSlaveCallable class, so nothin needed to change there, other than pointing to the logics new location.

Some tests were refactored to reflect the new location of the logic

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->

Related PR: https://github.com/jenkinsci/nexus-platform-plugin/pull/311
Which adding similar logic but closed in favor of this approach.